### PR TITLE
Upgrading phpstan & infection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,14 +19,14 @@
     "require-dev": {
         "ciaranmcnulty/phpspec-typehintedmethods": "^3.0",
         "friendsofphp/php-cs-fixer": "dev-long-line-fixers2",
-        "infection/infection": "^0.8.1",
+        "infection/infection": "^0.9@dev",
         "leanphp/phpspec-code-coverage": "^4.0",
         "mockery/mockery": "^1.0",
         "phing/phing": "^2.16",
         "phpmd/phpmd": "^2.6",
         "phpspec/phpspec": "^4.2",
-        "phpstan/phpstan": "^0.9.0",
-        "phpstan/phpstan-phpunit": "^0.9.0",
+        "phpstan/phpstan": "^0.10.0",
+        "phpstan/phpstan-phpunit": "^0.10.0",
         "phpunit/phpunit": "^7.0",
         "slevomat/coding-standard": "^4.0",
         "squizlabs/php_codesniffer": "^3.1"


### PR DESCRIPTION
Phpstan 0.10 is out and since it uses nikic/php-parser 4.x, we need to upgrade infection to 0.9 dev version too.