### PR TITLE
Define `asString()` & `asInt()` + deprecate `__toString()`

### DIFF
--- a/spec/Account/AccountAvatarUrlSpec.php
+++ b/spec/Account/AccountAvatarUrlSpec.php
@@ -31,7 +31,7 @@ class AccountAvatarUrlSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('https://avatars.githubusercontent.com/u/6752317?v=3');
+        $this->asString()->shouldReturn('https://avatars.githubusercontent.com/u/6752317?v=3');
     }
 
     public function it_can_be_serialized()

--- a/spec/Account/AccountIdSpec.php
+++ b/spec/Account/AccountIdSpec.php
@@ -26,7 +26,7 @@ class AccountIdSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('6752317');
+        $this->asString()->shouldReturn('6752317');
     }
 
     public function it_can_be_serialized()

--- a/spec/Account/AccountLoginSpec.php
+++ b/spec/Account/AccountLoginSpec.php
@@ -26,7 +26,7 @@ class AccountLoginSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('baxterthehacker');
+        $this->asString()->shouldReturn('baxterthehacker');
     }
 
     public function it_can_be_serialized()

--- a/spec/Application/ApplicationIdSpec.php
+++ b/spec/Application/ApplicationIdSpec.php
@@ -26,7 +26,7 @@ class ApplicationIdSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('177');
+        $this->asString()->shouldReturn('177');
     }
 
     public function it_can_be_serialized()

--- a/spec/Branch/BranchProtectionUrlSpec.php
+++ b/spec/Branch/BranchProtectionUrlSpec.php
@@ -31,7 +31,7 @@ class BranchProtectionUrlSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('protectionUrl');
+        $this->asString()->shouldReturn('protectionUrl');
     }
 
     public function it_can_be_serialized()

--- a/spec/Branch/Protection/RequiredStatusChecks/Context/ContextIdSpec.php
+++ b/spec/Branch/Protection/RequiredStatusChecks/Context/ContextIdSpec.php
@@ -26,7 +26,7 @@ class ContextIdSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('1');
+        $this->asString()->shouldReturn('1');
     }
 
     public function it_can_be_serialized()

--- a/spec/Branch/Protection/RequiredStatusChecks/RequiredStatusChecksEnforcementLevelSpec.php
+++ b/spec/Branch/Protection/RequiredStatusChecks/RequiredStatusChecksEnforcementLevelSpec.php
@@ -31,7 +31,7 @@ class RequiredStatusChecksEnforcementLevelSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('enforcementLevel');
+        $this->asString()->shouldReturn('enforcementLevel');
     }
 
     public function it_can_be_serialized()

--- a/spec/Commit/CommitCommentCountSpec.php
+++ b/spec/Commit/CommitCommentCountSpec.php
@@ -31,7 +31,7 @@ class CommitCommentCountSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('73');
+        $this->asString()->shouldReturn('73');
     }
 
     public function it_can_be_serialized()

--- a/spec/Commit/CommitCommentsUrlSpec.php
+++ b/spec/Commit/CommitCommentsUrlSpec.php
@@ -31,7 +31,7 @@ class CommitCommentsUrlSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('commentsUrl');
+        $this->asString()->shouldReturn('commentsUrl');
     }
 
     public function it_can_be_serialized()

--- a/spec/Commit/Verification/VerificationPayloadSpec.php
+++ b/spec/Commit/Verification/VerificationPayloadSpec.php
@@ -31,7 +31,7 @@ class VerificationPayloadSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('tree 691272480426f78a0138979dd3ce63b77f706feb\n...');
+        $this->asString()->shouldReturn('tree 691272480426f78a0138979dd3ce63b77f706feb\n...');
     }
 
     public function it_can_be_serialized()

--- a/spec/Commit/Verification/VerificationReasonSpec.php
+++ b/spec/Commit/Verification/VerificationReasonSpec.php
@@ -31,7 +31,7 @@ class VerificationReasonSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('expired_key');
+        $this->asString()->shouldReturn('expired_key');
     }
 
     public function it_can_be_serialized()

--- a/spec/Commit/Verification/VerificationSignatureSpec.php
+++ b/spec/Commit/Verification/VerificationSignatureSpec.php
@@ -31,7 +31,7 @@ class VerificationSignatureSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('-----BEGIN PGP MESSAGE-----\n...\n-----END PGP MESSAGE-----');
+        $this->asString()->shouldReturn('-----BEGIN PGP MESSAGE-----\n...\n-----END PGP MESSAGE-----');
     }
 
     public function it_can_be_serialized()

--- a/spec/Commit/Verification/VerificationVerifiedSpec.php
+++ b/spec/Commit/Verification/VerificationVerifiedSpec.php
@@ -31,7 +31,7 @@ class VerificationVerifiedSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('true');
+        $this->asString()->shouldReturn('true');
     }
 
     public function it_can_be_serialized()

--- a/spec/Installation/InstallationAccessTokenUrlSpec.php
+++ b/spec/Installation/InstallationAccessTokenUrlSpec.php
@@ -31,7 +31,7 @@ class InstallationAccessTokenUrlSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('access-token-url');
+        $this->asString()->shouldReturn('access-token-url');
     }
 
     public function it_can_be_serialized()

--- a/spec/Installation/InstallationCreatedAtSpec.php
+++ b/spec/Installation/InstallationCreatedAtSpec.php
@@ -24,12 +24,12 @@ class InstallationCreatedAtSpec extends ObjectBehavior
     public function it_can_be_created_from_custom_format()
     {
         $result = $this->createFromFormat(DateTime::ATOM, '2018-01-01T11:22:33Z');
-        $result->__toString()->shouldReturn('2018-01-01T11:22:33+00:00');
+        $result->asString()->shouldReturn('2018-01-01T11:22:33+00:00');
     }
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('2018-01-01T11:22:33+00:00');
+        $this->asString()->shouldReturn('2018-01-01T11:22:33+00:00');
     }
 
     public function it_can_be_serialized()

--- a/spec/Installation/InstallationHtmlUrlSpec.php
+++ b/spec/Installation/InstallationHtmlUrlSpec.php
@@ -31,7 +31,7 @@ class InstallationHtmlUrlSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('installationHtmlUrl');
+        $this->asString()->shouldReturn('installationHtmlUrl');
     }
 
     public function it_can_be_serialized()

--- a/spec/Installation/InstallationIdSpec.php
+++ b/spec/Installation/InstallationIdSpec.php
@@ -26,7 +26,7 @@ class InstallationIdSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('25235');
+        $this->asString()->shouldReturn('25235');
     }
 
     public function it_can_be_serialized()

--- a/spec/Installation/InstallationRepositoriesUrlSpec.php
+++ b/spec/Installation/InstallationRepositoriesUrlSpec.php
@@ -31,7 +31,7 @@ class InstallationRepositoriesUrlSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('installationRepositoriesUrl');
+        $this->asString()->shouldReturn('installationRepositoriesUrl');
     }
 
     public function it_can_be_serialized()

--- a/spec/Installation/InstallationRepositorySelection/InstallationRepositoryAllSpec.php
+++ b/spec/Installation/InstallationRepositorySelection/InstallationRepositoryAllSpec.php
@@ -29,6 +29,6 @@ class InstallationRepositoryAllSpec extends ObjectBehavior
 
     public function it_should_be_castable_to_string()
     {
-        $this->__toString()->shouldReturn('all');
+        $this->asString()->shouldReturn('all');
     }
 }

--- a/spec/Installation/InstallationRepositorySelection/InstallationRepositorySelectedSpec.php
+++ b/spec/Installation/InstallationRepositorySelection/InstallationRepositorySelectedSpec.php
@@ -29,6 +29,6 @@ class InstallationRepositorySelectedSpec extends ObjectBehavior
 
     public function it_should_be_castable_to_string()
     {
-        $this->__toString()->shouldReturn('selected');
+        $this->asString()->shouldReturn('selected');
     }
 }

--- a/spec/Installation/InstallationUpdatedAtSpec.php
+++ b/spec/Installation/InstallationUpdatedAtSpec.php
@@ -24,12 +24,12 @@ class InstallationUpdatedAtSpec extends ObjectBehavior
     public function it_can_be_created_from_custom_format()
     {
         $result = $this->createFromFormat(DateTime::ATOM, '2018-01-01T11:22:33Z');
-        $result->__toString()->shouldReturn('2018-01-01T11:22:33+00:00');
+        $result->asString()->shouldReturn('2018-01-01T11:22:33+00:00');
     }
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('2018-01-01T11:22:33+00:00');
+        $this->asString()->shouldReturn('2018-01-01T11:22:33+00:00');
     }
 
     public function it_can_be_serialized()

--- a/spec/Issue/IssueBodySpec.php
+++ b/spec/Issue/IssueBodySpec.php
@@ -26,7 +26,7 @@ class IssueBodySpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('value');
+        $this->asString()->shouldReturn('value');
     }
 
     public function it_can_be_serialized()

--- a/spec/Issue/IssueClosedAtSpec.php
+++ b/spec/Issue/IssueClosedAtSpec.php
@@ -24,12 +24,12 @@ class IssueClosedAtSpec extends ObjectBehavior
     public function it_can_be_created_from_custom_format()
     {
         $result = $this->createFromFormat(DateTime::ATOM, '2018-01-01T11:22:33Z');
-        $result->__toString()->shouldReturn('2018-01-01T11:22:33+00:00');
+        $result->asString()->shouldReturn('2018-01-01T11:22:33+00:00');
     }
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('2018-01-01T11:22:33+00:00');
+        $this->asString()->shouldReturn('2018-01-01T11:22:33+00:00');
     }
 
     public function it_can_be_serialized()

--- a/spec/Issue/IssueCreatedAtSpec.php
+++ b/spec/Issue/IssueCreatedAtSpec.php
@@ -24,12 +24,12 @@ class IssueCreatedAtSpec extends ObjectBehavior
     public function it_can_be_created_from_custom_format()
     {
         $result = $this->createFromFormat(DateTime::ATOM, '2018-01-01T11:22:33Z');
-        $result->__toString()->shouldReturn('2018-01-01T11:22:33+00:00');
+        $result->asString()->shouldReturn('2018-01-01T11:22:33+00:00');
     }
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('2018-01-01T11:22:33+00:00');
+        $this->asString()->shouldReturn('2018-01-01T11:22:33+00:00');
     }
 
     public function it_can_be_serialized()

--- a/spec/Issue/IssueIdSpec.php
+++ b/spec/Issue/IssueIdSpec.php
@@ -26,7 +26,7 @@ class IssueIdSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('1');
+        $this->asString()->shouldReturn('1');
     }
 
     public function it_can_be_serialized()

--- a/spec/Issue/IssueNumberSpec.php
+++ b/spec/Issue/IssueNumberSpec.php
@@ -26,7 +26,7 @@ class IssueNumberSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('1');
+        $this->asString()->shouldReturn('1');
     }
 
     public function it_can_be_serialized()

--- a/spec/Issue/IssueStateSpec.php
+++ b/spec/Issue/IssueStateSpec.php
@@ -26,7 +26,7 @@ class IssueStateSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('open');
+        $this->asString()->shouldReturn('open');
     }
 
     public function it_can_be_serialized()

--- a/spec/Issue/IssueTitleSpec.php
+++ b/spec/Issue/IssueTitleSpec.php
@@ -26,7 +26,7 @@ class IssueTitleSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('value');
+        $this->asString()->shouldReturn('value');
     }
 
     public function it_can_be_serialized()

--- a/spec/Issue/IssueUpdatedAtSpec.php
+++ b/spec/Issue/IssueUpdatedAtSpec.php
@@ -24,12 +24,12 @@ class IssueUpdatedAtSpec extends ObjectBehavior
     public function it_can_be_created_from_custom_format()
     {
         $result = $this->createFromFormat(DateTime::ATOM, '2018-01-01T11:22:33Z');
-        $result->__toString()->shouldReturn('2018-01-01T11:22:33+00:00');
+        $result->asString()->shouldReturn('2018-01-01T11:22:33+00:00');
     }
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('2018-01-01T11:22:33+00:00');
+        $this->asString()->shouldReturn('2018-01-01T11:22:33+00:00');
     }
 
     public function it_can_be_serialized()

--- a/spec/IssueComment/IssueCommentBodySpec.php
+++ b/spec/IssueComment/IssueCommentBodySpec.php
@@ -26,7 +26,7 @@ class IssueCommentBodySpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('value');
+        $this->asString()->shouldReturn('value');
     }
 
     public function it_can_be_serialized()

--- a/spec/IssueComment/IssueCommentCreatedAtSpec.php
+++ b/spec/IssueComment/IssueCommentCreatedAtSpec.php
@@ -24,12 +24,12 @@ class IssueCommentCreatedAtSpec extends ObjectBehavior
     public function it_can_be_created_from_custom_format()
     {
         $result = $this->createFromFormat(DateTime::ATOM, '2018-01-01T11:22:33Z');
-        $result->__toString()->shouldReturn('2018-01-01T11:22:33+00:00');
+        $result->asString()->shouldReturn('2018-01-01T11:22:33+00:00');
     }
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('2018-01-01T11:22:33+00:00');
+        $this->asString()->shouldReturn('2018-01-01T11:22:33+00:00');
     }
 
     public function it_can_be_serialized()

--- a/spec/IssueComment/IssueCommentIdSpec.php
+++ b/spec/IssueComment/IssueCommentIdSpec.php
@@ -26,7 +26,7 @@ class IssueCommentIdSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('1');
+        $this->asString()->shouldReturn('1');
     }
 
     public function it_can_be_serialized()

--- a/spec/IssueComment/IssueCommentUpdatedAtSpec.php
+++ b/spec/IssueComment/IssueCommentUpdatedAtSpec.php
@@ -24,12 +24,12 @@ class IssueCommentUpdatedAtSpec extends ObjectBehavior
     public function it_can_be_created_from_custom_format()
     {
         $result = $this->createFromFormat(DateTime::ATOM, '2018-01-01T11:22:33Z');
-        $result->__toString()->shouldReturn('2018-01-01T11:22:33+00:00');
+        $result->asString()->shouldReturn('2018-01-01T11:22:33+00:00');
     }
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('2018-01-01T11:22:33+00:00');
+        $this->asString()->shouldReturn('2018-01-01T11:22:33+00:00');
     }
 
     public function it_can_be_serialized()

--- a/spec/Label/LabelColorSpec.php
+++ b/spec/Label/LabelColorSpec.php
@@ -31,7 +31,7 @@ class LabelColorSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('color');
+        $this->asString()->shouldReturn('color');
     }
 
     public function it_can_be_serialized()

--- a/spec/Label/LabelIdSpec.php
+++ b/spec/Label/LabelIdSpec.php
@@ -26,7 +26,7 @@ class LabelIdSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('1');
+        $this->asString()->shouldReturn('1');
     }
 
     public function it_can_be_serialized()

--- a/spec/Label/LabelNameSpec.php
+++ b/spec/Label/LabelNameSpec.php
@@ -26,7 +26,7 @@ class LabelNameSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('value');
+        $this->asString()->shouldReturn('value');
     }
 
     public function it_can_be_serialized()

--- a/spec/Milestone/MilestoneClosedAtSpec.php
+++ b/spec/Milestone/MilestoneClosedAtSpec.php
@@ -24,12 +24,12 @@ class MilestoneClosedAtSpec extends ObjectBehavior
     public function it_can_be_created_from_custom_format()
     {
         $result = $this->createFromFormat(DateTime::ATOM, '2018-01-01T11:22:33Z');
-        $result->__toString()->shouldReturn('2018-01-01T11:22:33+00:00');
+        $result->asString()->shouldReturn('2018-01-01T11:22:33+00:00');
     }
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('2018-01-01T11:22:33+00:00');
+        $this->asString()->shouldReturn('2018-01-01T11:22:33+00:00');
     }
 
     public function it_can_be_serialized()

--- a/spec/Milestone/MilestoneCreatedAtSpec.php
+++ b/spec/Milestone/MilestoneCreatedAtSpec.php
@@ -24,12 +24,12 @@ class MilestoneCreatedAtSpec extends ObjectBehavior
     public function it_can_be_created_from_custom_format()
     {
         $result = $this->createFromFormat(DateTime::ATOM, '2018-01-01T11:22:33Z');
-        $result->__toString()->shouldReturn('2018-01-01T11:22:33+00:00');
+        $result->asString()->shouldReturn('2018-01-01T11:22:33+00:00');
     }
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('2018-01-01T11:22:33+00:00');
+        $this->asString()->shouldReturn('2018-01-01T11:22:33+00:00');
     }
 
     public function it_can_be_serialized()

--- a/spec/Milestone/MilestoneDescriptionSpec.php
+++ b/spec/Milestone/MilestoneDescriptionSpec.php
@@ -26,7 +26,7 @@ class MilestoneDescriptionSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('value');
+        $this->asString()->shouldReturn('value');
     }
 
     public function it_can_be_serialized()

--- a/spec/Milestone/MilestoneDueOnSpec.php
+++ b/spec/Milestone/MilestoneDueOnSpec.php
@@ -24,12 +24,12 @@ class MilestoneDueOnSpec extends ObjectBehavior
     public function it_can_be_created_from_custom_format()
     {
         $result = $this->createFromFormat(DateTime::ATOM, '2018-01-01T11:22:33Z');
-        $result->__toString()->shouldReturn('2018-01-01T11:22:33+00:00');
+        $result->asString()->shouldReturn('2018-01-01T11:22:33+00:00');
     }
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('2018-01-01T11:22:33+00:00');
+        $this->asString()->shouldReturn('2018-01-01T11:22:33+00:00');
     }
 
     public function it_can_be_serialized()

--- a/spec/Milestone/MilestoneIdSpec.php
+++ b/spec/Milestone/MilestoneIdSpec.php
@@ -26,7 +26,7 @@ class MilestoneIdSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('1');
+        $this->asString()->shouldReturn('1');
     }
 
     public function it_can_be_serialized()

--- a/spec/Milestone/MilestoneNumberSpec.php
+++ b/spec/Milestone/MilestoneNumberSpec.php
@@ -26,7 +26,7 @@ class MilestoneNumberSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('1');
+        $this->asString()->shouldReturn('1');
     }
 
     public function it_can_be_serialized()

--- a/spec/Milestone/MilestoneStateSpec.php
+++ b/spec/Milestone/MilestoneStateSpec.php
@@ -26,7 +26,7 @@ class MilestoneStateSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('open');
+        $this->asString()->shouldReturn('open');
     }
 
     public function it_can_be_serialized()

--- a/spec/Milestone/MilestoneTitleSpec.php
+++ b/spec/Milestone/MilestoneTitleSpec.php
@@ -26,7 +26,7 @@ class MilestoneTitleSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('value');
+        $this->asString()->shouldReturn('value');
     }
 
     public function it_can_be_serialized()

--- a/spec/Milestone/MilestoneUpdatedAtSpec.php
+++ b/spec/Milestone/MilestoneUpdatedAtSpec.php
@@ -24,12 +24,12 @@ class MilestoneUpdatedAtSpec extends ObjectBehavior
     public function it_can_be_created_from_custom_format()
     {
         $result = $this->createFromFormat(DateTime::ATOM, '2018-01-01T11:22:33Z');
-        $result->__toString()->shouldReturn('2018-01-01T11:22:33+00:00');
+        $result->asString()->shouldReturn('2018-01-01T11:22:33+00:00');
     }
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('2018-01-01T11:22:33+00:00');
+        $this->asString()->shouldReturn('2018-01-01T11:22:33+00:00');
     }
 
     public function it_can_be_serialized()

--- a/spec/PullRequest/PullRequestAuthorAssociationSpec.php
+++ b/spec/PullRequest/PullRequestAuthorAssociationSpec.php
@@ -26,7 +26,7 @@ class PullRequestAuthorAssociationSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('COLLABORATOR');
+        $this->asString()->shouldReturn('COLLABORATOR');
     }
 
     public function it_can_be_serialized()

--- a/spec/PullRequest/PullRequestBodySpec.php
+++ b/spec/PullRequest/PullRequestBodySpec.php
@@ -26,7 +26,7 @@ class PullRequestBodySpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('value');
+        $this->asString()->shouldReturn('value');
     }
 
     public function it_can_be_serialized()

--- a/spec/PullRequest/PullRequestClosedAtSpec.php
+++ b/spec/PullRequest/PullRequestClosedAtSpec.php
@@ -24,12 +24,12 @@ class PullRequestClosedAtSpec extends ObjectBehavior
     public function it_can_be_created_from_custom_format()
     {
         $result = $this->createFromFormat(DateTime::ATOM, '2018-01-01T11:22:33Z');
-        $result->__toString()->shouldReturn('2018-01-01T11:22:33+00:00');
+        $result->asString()->shouldReturn('2018-01-01T11:22:33+00:00');
     }
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('2018-01-01T11:22:33+00:00');
+        $this->asString()->shouldReturn('2018-01-01T11:22:33+00:00');
     }
 
     public function it_can_be_serialized()

--- a/spec/PullRequest/PullRequestCreatedAtSpec.php
+++ b/spec/PullRequest/PullRequestCreatedAtSpec.php
@@ -24,12 +24,12 @@ class PullRequestCreatedAtSpec extends ObjectBehavior
     public function it_can_be_created_from_custom_format()
     {
         $result = $this->createFromFormat(DateTime::ATOM, '2018-01-01T11:22:33Z');
-        $result->__toString()->shouldReturn('2018-01-01T11:22:33+00:00');
+        $result->asString()->shouldReturn('2018-01-01T11:22:33+00:00');
     }
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('2018-01-01T11:22:33+00:00');
+        $this->asString()->shouldReturn('2018-01-01T11:22:33+00:00');
     }
 
     public function it_can_be_serialized()

--- a/spec/PullRequest/PullRequestIdSpec.php
+++ b/spec/PullRequest/PullRequestIdSpec.php
@@ -26,7 +26,7 @@ class PullRequestIdSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('1');
+        $this->asString()->shouldReturn('1');
     }
 
     public function it_can_be_serialized()

--- a/spec/PullRequest/PullRequestNumberSpec.php
+++ b/spec/PullRequest/PullRequestNumberSpec.php
@@ -26,7 +26,7 @@ class PullRequestNumberSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('1');
+        $this->asString()->shouldReturn('1');
     }
 
     public function it_can_be_serialized()

--- a/spec/PullRequest/PullRequestTitleSpec.php
+++ b/spec/PullRequest/PullRequestTitleSpec.php
@@ -26,7 +26,7 @@ class PullRequestTitleSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('value');
+        $this->asString()->shouldReturn('value');
     }
 
     public function it_can_be_serialized()

--- a/spec/PullRequest/PullRequestUpdatedAtSpec.php
+++ b/spec/PullRequest/PullRequestUpdatedAtSpec.php
@@ -24,12 +24,12 @@ class PullRequestUpdatedAtSpec extends ObjectBehavior
     public function it_can_be_created_from_custom_format()
     {
         $result = $this->createFromFormat(DateTime::ATOM, '2018-01-01T11:22:33Z');
-        $result->__toString()->shouldReturn('2018-01-01T11:22:33+00:00');
+        $result->asString()->shouldReturn('2018-01-01T11:22:33+00:00');
     }
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('2018-01-01T11:22:33+00:00');
+        $this->asString()->shouldReturn('2018-01-01T11:22:33+00:00');
     }
 
     public function it_can_be_serialized()

--- a/spec/PullRequestReview/PullRequestReviewAuthorAssociationSpec.php
+++ b/spec/PullRequestReview/PullRequestReviewAuthorAssociationSpec.php
@@ -26,7 +26,7 @@ class PullRequestReviewAuthorAssociationSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('COLLABORATOR');
+        $this->asString()->shouldReturn('COLLABORATOR');
     }
 
     public function it_can_be_serialized()

--- a/spec/PullRequestReview/PullRequestReviewBodySpec.php
+++ b/spec/PullRequestReview/PullRequestReviewBodySpec.php
@@ -26,7 +26,7 @@ class PullRequestReviewBodySpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('value');
+        $this->asString()->shouldReturn('value');
     }
 
     public function it_can_be_serialized()

--- a/spec/PullRequestReview/PullRequestReviewHtmlUrlSpec.php
+++ b/spec/PullRequestReview/PullRequestReviewHtmlUrlSpec.php
@@ -31,7 +31,7 @@ class PullRequestReviewHtmlUrlSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('htmlUrl');
+        $this->asString()->shouldReturn('htmlUrl');
     }
 
     public function it_can_be_serialized()

--- a/spec/PullRequestReview/PullRequestReviewIdSpec.php
+++ b/spec/PullRequestReview/PullRequestReviewIdSpec.php
@@ -26,7 +26,7 @@ class PullRequestReviewIdSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('1');
+        $this->asString()->shouldReturn('1');
     }
 
     public function it_can_be_serialized()

--- a/spec/PullRequestReview/PullRequestReviewStateSpec.php
+++ b/spec/PullRequestReview/PullRequestReviewStateSpec.php
@@ -26,7 +26,7 @@ class PullRequestReviewStateSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('approved');
+        $this->asString()->shouldReturn('approved');
     }
 
     public function it_can_be_serialized()

--- a/spec/PullRequestReview/PullRequestReviewSubmittedAtSpec.php
+++ b/spec/PullRequestReview/PullRequestReviewSubmittedAtSpec.php
@@ -24,12 +24,12 @@ class PullRequestReviewSubmittedAtSpec extends ObjectBehavior
     public function it_can_be_created_from_custom_format()
     {
         $result = $this->createFromFormat(DateTime::ATOM, '2018-01-01T11:22:33Z');
-        $result->__toString()->shouldReturn('2018-01-01T11:22:33+00:00');
+        $result->asString()->shouldReturn('2018-01-01T11:22:33+00:00');
     }
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('2018-01-01T11:22:33+00:00');
+        $this->asString()->shouldReturn('2018-01-01T11:22:33+00:00');
     }
 
     public function it_can_be_serialized()

--- a/spec/Repo/RepoCreatedAtSpec.php
+++ b/spec/Repo/RepoCreatedAtSpec.php
@@ -24,12 +24,12 @@ class RepoCreatedAtSpec extends ObjectBehavior
     public function it_can_be_created_from_custom_format()
     {
         $result = $this->createFromFormat(DateTime::ATOM, '2018-01-01T11:22:33Z');
-        $result->__toString()->shouldReturn('2018-01-01T11:22:33+00:00');
+        $result->asString()->shouldReturn('2018-01-01T11:22:33+00:00');
     }
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('2018-01-01T11:22:33+00:00');
+        $this->asString()->shouldReturn('2018-01-01T11:22:33+00:00');
     }
 
     public function it_can_be_serialized()

--- a/spec/Repo/RepoDescriptionSpec.php
+++ b/spec/Repo/RepoDescriptionSpec.php
@@ -37,7 +37,7 @@ class RepoDescriptionSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn(
+        $this->asString()->shouldReturn(
             'Language Savant. If your repository language is being reported incorrectly, send us a pull request!'
         );
     }

--- a/spec/Repo/RepoEndpoints/RepoApiUrlSpec.php
+++ b/spec/Repo/RepoEndpoints/RepoApiUrlSpec.php
@@ -31,7 +31,7 @@ class RepoApiUrlSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('https://api.github.com/repos/octocat/linguist');
+        $this->asString()->shouldReturn('https://api.github.com/repos/octocat/linguist');
     }
 
     public function it_can_be_serialized()

--- a/spec/Repo/RepoEndpoints/RepoGitUrlSpec.php
+++ b/spec/Repo/RepoEndpoints/RepoGitUrlSpec.php
@@ -31,7 +31,7 @@ class RepoGitUrlSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('git://github.com/octocat/linguist.git');
+        $this->asString()->shouldReturn('git://github.com/octocat/linguist.git');
     }
 
     public function it_can_be_serialized()

--- a/spec/Repo/RepoEndpoints/RepoHtmlUrlSpec.php
+++ b/spec/Repo/RepoEndpoints/RepoHtmlUrlSpec.php
@@ -31,7 +31,7 @@ class RepoHtmlUrlSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('https://github.com/octocat/linguist');
+        $this->asString()->shouldReturn('https://github.com/octocat/linguist');
     }
 
     public function it_can_be_serialized()

--- a/spec/Repo/RepoEndpoints/RepoSshUrlSpec.php
+++ b/spec/Repo/RepoEndpoints/RepoSshUrlSpec.php
@@ -31,7 +31,7 @@ class RepoSshUrlSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('git@github.com:octocat/linguist.git');
+        $this->asString()->shouldReturn('git@github.com:octocat/linguist.git');
     }
 
     public function it_can_be_serialized()

--- a/spec/Repo/RepoHomepageSpec.php
+++ b/spec/Repo/RepoHomepageSpec.php
@@ -31,7 +31,7 @@ class RepoHomepageSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('http://www.example.com/');
+        $this->asString()->shouldReturn('http://www.example.com/');
     }
 
     public function it_can_be_serialized()

--- a/spec/Repo/RepoIdSpec.php
+++ b/spec/Repo/RepoIdSpec.php
@@ -26,7 +26,7 @@ class RepoIdSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('64778136');
+        $this->asString()->shouldReturn('64778136');
     }
 
     public function it_can_be_serialized()

--- a/spec/Repo/RepoLanguageSpec.php
+++ b/spec/Repo/RepoLanguageSpec.php
@@ -31,7 +31,7 @@ class RepoLanguageSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('CSS');
+        $this->asString()->shouldReturn('CSS');
     }
 
     public function it_can_be_serialized()

--- a/spec/Repo/RepoMirrorUrlSpec.php
+++ b/spec/Repo/RepoMirrorUrlSpec.php
@@ -31,7 +31,7 @@ class RepoMirrorUrlSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('http://mirror.example.com');
+        $this->asString()->shouldReturn('http://mirror.example.com');
     }
 
     public function it_can_be_serialized()

--- a/spec/Repo/RepoNameSpec.php
+++ b/spec/Repo/RepoNameSpec.php
@@ -31,7 +31,7 @@ class RepoNameSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('linguist');
+        $this->asString()->shouldReturn('linguist');
     }
 
     public function it_can_be_serialized()

--- a/spec/Repo/RepoPushedAtSpec.php
+++ b/spec/Repo/RepoPushedAtSpec.php
@@ -24,12 +24,12 @@ class RepoPushedAtSpec extends ObjectBehavior
     public function it_can_be_created_from_custom_format()
     {
         $result = $this->createFromFormat(DateTime::ATOM, '2018-01-01T11:22:33Z');
-        $result->__toString()->shouldReturn('2018-01-01T11:22:33+00:00');
+        $result->asString()->shouldReturn('2018-01-01T11:22:33+00:00');
     }
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('2018-01-01T11:22:33+00:00');
+        $this->asString()->shouldReturn('2018-01-01T11:22:33+00:00');
     }
 
     public function it_can_be_serialized()

--- a/spec/Repo/RepoStats/RepoSizeSpec.php
+++ b/spec/Repo/RepoStats/RepoSizeSpec.php
@@ -31,7 +31,7 @@ class RepoSizeSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('32899');
+        $this->asString()->shouldReturn('32899');
     }
 
     public function it_can_be_serialized()

--- a/spec/Repo/RepoUpdatedAtSpec.php
+++ b/spec/Repo/RepoUpdatedAtSpec.php
@@ -24,12 +24,12 @@ class RepoUpdatedAtSpec extends ObjectBehavior
     public function it_can_be_created_from_custom_format()
     {
         $result = $this->createFromFormat(DateTime::ATOM, '2018-01-01T11:22:33Z');
-        $result->__toString()->shouldReturn('2018-01-01T11:22:33+00:00');
+        $result->asString()->shouldReturn('2018-01-01T11:22:33+00:00');
     }
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('2018-01-01T11:22:33+00:00');
+        $this->asString()->shouldReturn('2018-01-01T11:22:33+00:00');
     }
 
     public function it_can_be_serialized()

--- a/spec/StatsSpec.php
+++ b/spec/StatsSpec.php
@@ -26,6 +26,6 @@ abstract class StatsSpec extends ObjectBehavior
 
     public function it_should_be_castable_to_string()
     {
-        $this->__toString()->shouldReturn('123');
+        $this->asString()->shouldReturn('123');
     }
 }

--- a/spec/StatusCheck/StatusCheckContextSpec.php
+++ b/spec/StatusCheck/StatusCheckContextSpec.php
@@ -31,7 +31,7 @@ class StatusCheckContextSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('ci/circleci');
+        $this->asString()->shouldReturn('ci/circleci');
     }
 
     public function it_can_be_serialized()

--- a/spec/StatusCheck/StatusCheckDescriptionSpec.php
+++ b/spec/StatusCheck/StatusCheckDescriptionSpec.php
@@ -26,7 +26,7 @@ class StatusCheckDescriptionSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('value');
+        $this->asString()->shouldReturn('value');
     }
 
     public function it_can_be_serialized()

--- a/spec/StatusCheck/StatusCheckIdSpec.php
+++ b/spec/StatusCheck/StatusCheckIdSpec.php
@@ -26,7 +26,7 @@ class StatusCheckIdSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('1');
+        $this->asString()->shouldReturn('1');
     }
 
     public function it_can_be_serialized()

--- a/spec/StatusCheck/StatusCheckTargetUrlSpec.php
+++ b/spec/StatusCheck/StatusCheckTargetUrlSpec.php
@@ -37,7 +37,7 @@ class StatusCheckTargetUrlSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn(
+        $this->asString()->shouldReturn(
             'https://circleci.com/gh/msvrtan/generator/231?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link'
         );
     }

--- a/spec/User/UserAvatarUrlSpec.php
+++ b/spec/User/UserAvatarUrlSpec.php
@@ -33,7 +33,7 @@ class UserAvatarUrlSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('https://avatars3.githubusercontent.com/u/583231?v=4');
+        $this->asString()->shouldReturn('https://avatars3.githubusercontent.com/u/583231?v=4');
     }
 
     public function it_can_be_serialized()

--- a/spec/User/UserIdSpec.php
+++ b/spec/User/UserIdSpec.php
@@ -28,7 +28,7 @@ class UserIdSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('583231');
+        $this->asString()->shouldReturn('583231');
     }
 
     public function it_can_be_serialized()

--- a/spec/User/UserLoginSpec.php
+++ b/spec/User/UserLoginSpec.php
@@ -28,7 +28,7 @@ class UserLoginSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
-        $this->__toString()->shouldReturn('octocat');
+        $this->asString()->shouldReturn('octocat');
     }
 
     public function it_can_be_serialized()

--- a/src/Account/AccountAvatarUrl.php
+++ b/src/Account/AccountAvatarUrl.php
@@ -28,6 +28,14 @@ class AccountAvatarUrl
         return $this->avatarUrl;
     }
 
+    public function asString(): string
+    {
+        return $this->avatarUrl;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->avatarUrl;

--- a/src/Account/AccountId.php
+++ b/src/Account/AccountId.php
@@ -27,6 +27,19 @@ class AccountId
         return $this->id;
     }
 
+    public function asInt(): int
+    {
+        return $this->id;
+    }
+
+    public function asString(): string
+    {
+        return (string) $this->id;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return (string) $this->id;

--- a/src/Account/AccountLogin.php
+++ b/src/Account/AccountLogin.php
@@ -23,6 +23,14 @@ class AccountLogin
         return $this->value;
     }
 
+    public function asString(): string
+    {
+        return $this->value;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->value;

--- a/src/Account/AccountType.php
+++ b/src/Account/AccountType.php
@@ -18,6 +18,11 @@ class AccountType extends Enum
 
     const BOT = 'Bot';
 
+    public function asString(): string
+    {
+        return $this->value;
+    }
+
     public function serialize(): string
     {
         return $this->value;

--- a/src/Application/ApplicationId.php
+++ b/src/Application/ApplicationId.php
@@ -26,6 +26,19 @@ class ApplicationId
         return $this->id;
     }
 
+    public function asInt(): int
+    {
+        return $this->id;
+    }
+
+    public function asString(): string
+    {
+        return (string) $this->id;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return (string) $this->id;

--- a/src/Branch/BranchProtectionUrl.php
+++ b/src/Branch/BranchProtectionUrl.php
@@ -28,6 +28,14 @@ class BranchProtectionUrl
         return $this->protectionUrl;
     }
 
+    public function asString(): string
+    {
+        return $this->protectionUrl;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->protectionUrl;

--- a/src/Branch/Protection/RequiredStatusChecks/Context/ContextId.php
+++ b/src/Branch/Protection/RequiredStatusChecks/Context/ContextId.php
@@ -26,6 +26,19 @@ class ContextId
         return $this->id;
     }
 
+    public function asInt(): int
+    {
+        return $this->id;
+    }
+
+    public function asString(): string
+    {
+        return (string) $this->id;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return (string) $this->id;

--- a/src/Branch/Protection/RequiredStatusChecks/RequiredStatusChecksEnforcementLevel.php
+++ b/src/Branch/Protection/RequiredStatusChecks/RequiredStatusChecksEnforcementLevel.php
@@ -28,6 +28,14 @@ class RequiredStatusChecksEnforcementLevel
         return $this->enforcementLevel;
     }
 
+    public function asString(): string
+    {
+        return $this->enforcementLevel;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->enforcementLevel;

--- a/src/Build/BuildStatus.php
+++ b/src/Build/BuildStatus.php
@@ -19,6 +19,14 @@ abstract class BuildStatus
         return $this->getName();
     }
 
+    public function asString(): string
+    {
+        return $this->getName();
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->getName();

--- a/src/Commit/CommitCommentCount.php
+++ b/src/Commit/CommitCommentCount.php
@@ -28,6 +28,14 @@ class CommitCommentCount
         return $this->commentCount;
     }
 
+    public function asString(): string
+    {
+        return (string) $this->commentCount;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return (string) $this->commentCount;

--- a/src/Commit/CommitCommentsUrl.php
+++ b/src/Commit/CommitCommentsUrl.php
@@ -28,6 +28,14 @@ class CommitCommentsUrl
         return $this->commentsUrl;
     }
 
+    public function asString(): string
+    {
+        return $this->commentsUrl;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->commentsUrl;

--- a/src/Commit/Verification/VerificationPayload.php
+++ b/src/Commit/Verification/VerificationPayload.php
@@ -28,6 +28,14 @@ class VerificationPayload
         return $this->payload;
     }
 
+    public function asString(): string
+    {
+        return $this->payload;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->payload;

--- a/src/Commit/Verification/VerificationReason.php
+++ b/src/Commit/Verification/VerificationReason.php
@@ -28,6 +28,14 @@ class VerificationReason
         return $this->reason;
     }
 
+    public function asString(): string
+    {
+        return $this->reason;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->reason;

--- a/src/Commit/Verification/VerificationSignature.php
+++ b/src/Commit/Verification/VerificationSignature.php
@@ -28,6 +28,14 @@ class VerificationSignature
         return $this->signature;
     }
 
+    public function asString(): string
+    {
+        return $this->signature;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->signature;

--- a/src/Commit/Verification/VerificationVerified.php
+++ b/src/Commit/Verification/VerificationVerified.php
@@ -28,6 +28,18 @@ class VerificationVerified
         return $this->verified;
     }
 
+    public function asString(): string
+    {
+        if (true === $this->verified) {
+            return 'true';
+        } else {
+            return 'false';
+        }
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         if (true === $this->verified) {

--- a/src/External/ExternalService.php
+++ b/src/External/ExternalService.php
@@ -18,6 +18,14 @@ abstract class ExternalService
 
     abstract public function getValue(): string;
 
+    public function asString(): string
+    {
+        return $this->getValue();
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->getValue();

--- a/src/Installation/InstallationAccessTokenUrl.php
+++ b/src/Installation/InstallationAccessTokenUrl.php
@@ -28,6 +28,14 @@ class InstallationAccessTokenUrl
         return $this->accessTokenUrl;
     }
 
+    public function asString(): string
+    {
+        return $this->accessTokenUrl;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->accessTokenUrl;

--- a/src/Installation/InstallationCreatedAt.php
+++ b/src/Installation/InstallationCreatedAt.php
@@ -24,6 +24,14 @@ class InstallationCreatedAt extends DateTime
         return new self($date->format('c'));
     }
 
+    public function asString(): string
+    {
+        return $this->format('c');
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->format('c');
@@ -31,7 +39,7 @@ class InstallationCreatedAt extends DateTime
 
     public function serialize(): string
     {
-        return $this->__toString();
+        return $this->asString();
     }
 
     public static function deserialize($value): self

--- a/src/Installation/InstallationHtmlUrl.php
+++ b/src/Installation/InstallationHtmlUrl.php
@@ -28,6 +28,14 @@ class InstallationHtmlUrl
         return $this->installationHtmlUrl;
     }
 
+    public function asString(): string
+    {
+        return $this->installationHtmlUrl;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->installationHtmlUrl;

--- a/src/Installation/InstallationId.php
+++ b/src/Installation/InstallationId.php
@@ -26,6 +26,19 @@ class InstallationId
         return $this->id;
     }
 
+    public function asInt(): int
+    {
+        return $this->id;
+    }
+
+    public function asString(): string
+    {
+        return (string) $this->id;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return (string) $this->id;

--- a/src/Installation/InstallationRepositoriesUrl.php
+++ b/src/Installation/InstallationRepositoriesUrl.php
@@ -28,6 +28,14 @@ class InstallationRepositoriesUrl
         return $this->installationRepositoriesUrl;
     }
 
+    public function asString(): string
+    {
+        return $this->installationRepositoriesUrl;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->installationRepositoriesUrl;

--- a/src/Installation/InstallationRepositorySelection.php
+++ b/src/Installation/InstallationRepositorySelection.php
@@ -16,6 +16,11 @@ interface InstallationRepositorySelection
 
     public function getValue(): string;
 
+    public function asString(): string;
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string;
 
     public function serialize(): string;

--- a/src/Installation/InstallationRepositorySelection/InstallationRepositoryAll.php
+++ b/src/Installation/InstallationRepositorySelection/InstallationRepositoryAll.php
@@ -29,6 +29,14 @@ class InstallationRepositoryAll implements InstallationRepositorySelection
         return self::NAME;
     }
 
+    public function asString(): string
+    {
+        return self::NAME;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return self::NAME;

--- a/src/Installation/InstallationRepositorySelection/InstallationRepositorySelected.php
+++ b/src/Installation/InstallationRepositorySelection/InstallationRepositorySelected.php
@@ -29,6 +29,14 @@ class InstallationRepositorySelected implements InstallationRepositorySelection
         return self::NAME;
     }
 
+    public function asString(): string
+    {
+        return self::NAME;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return self::NAME;

--- a/src/Installation/InstallationUpdatedAt.php
+++ b/src/Installation/InstallationUpdatedAt.php
@@ -24,6 +24,14 @@ class InstallationUpdatedAt extends DateTime
         return new self($date->format('c'));
     }
 
+    public function asString(): string
+    {
+        return $this->format('c');
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->format('c');
@@ -31,7 +39,7 @@ class InstallationUpdatedAt extends DateTime
 
     public function serialize(): string
     {
-        return $this->__toString();
+        return $this->asString();
     }
 
     public static function deserialize($value): self

--- a/src/Issue/IssueBody.php
+++ b/src/Issue/IssueBody.php
@@ -23,6 +23,14 @@ class IssueBody
         return $this->value;
     }
 
+    public function asString(): string
+    {
+        return $this->value;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->value;

--- a/src/Issue/IssueClosedAt.php
+++ b/src/Issue/IssueClosedAt.php
@@ -24,6 +24,14 @@ class IssueClosedAt extends DateTime
         return new self($date->format('c'));
     }
 
+    public function asString(): string
+    {
+        return $this->format('c');
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->format('c');
@@ -31,7 +39,7 @@ class IssueClosedAt extends DateTime
 
     public function serialize(): string
     {
-        return $this->__toString();
+        return $this->asString();
     }
 
     public static function deserialize($value): self

--- a/src/Issue/IssueCreatedAt.php
+++ b/src/Issue/IssueCreatedAt.php
@@ -24,6 +24,14 @@ class IssueCreatedAt extends DateTime
         return new self($date->format('c'));
     }
 
+    public function asString(): string
+    {
+        return $this->format('c');
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->format('c');
@@ -31,7 +39,7 @@ class IssueCreatedAt extends DateTime
 
     public function serialize(): string
     {
-        return $this->__toString();
+        return $this->asString();
     }
 
     public static function deserialize($value): self

--- a/src/Issue/IssueId.php
+++ b/src/Issue/IssueId.php
@@ -26,6 +26,19 @@ class IssueId
         return $this->id;
     }
 
+    public function asInt(): int
+    {
+        return $this->id;
+    }
+
+    public function asString(): string
+    {
+        return (string) $this->id;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return (string) $this->id;

--- a/src/Issue/IssueNumber.php
+++ b/src/Issue/IssueNumber.php
@@ -23,6 +23,19 @@ class IssueNumber
         return $this->value;
     }
 
+    public function asInt(): int
+    {
+        return $this->value;
+    }
+
+    public function asString(): string
+    {
+        return (string) $this->value;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return (string) $this->value;

--- a/src/Issue/IssueState.php
+++ b/src/Issue/IssueState.php
@@ -21,6 +21,11 @@ class IssueState extends Enum
         return $this->value;
     }
 
+    public function asString(): string
+    {
+        return $this->value;
+    }
+
     public static function deserialize(string $value): self
     {
         return new self($value);

--- a/src/Issue/IssueTitle.php
+++ b/src/Issue/IssueTitle.php
@@ -23,6 +23,14 @@ class IssueTitle
         return $this->value;
     }
 
+    public function asString(): string
+    {
+        return $this->value;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->value;

--- a/src/Issue/IssueUpdatedAt.php
+++ b/src/Issue/IssueUpdatedAt.php
@@ -24,6 +24,14 @@ class IssueUpdatedAt extends DateTime
         return new self($date->format('c'));
     }
 
+    public function asString(): string
+    {
+        return $this->format('c');
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->format('c');
@@ -31,7 +39,7 @@ class IssueUpdatedAt extends DateTime
 
     public function serialize(): string
     {
-        return $this->__toString();
+        return $this->asString();
     }
 
     public static function deserialize($value): self

--- a/src/IssueComment/IssueCommentBody.php
+++ b/src/IssueComment/IssueCommentBody.php
@@ -23,6 +23,14 @@ class IssueCommentBody
         return $this->value;
     }
 
+    public function asString(): string
+    {
+        return $this->value;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->value;

--- a/src/IssueComment/IssueCommentCreatedAt.php
+++ b/src/IssueComment/IssueCommentCreatedAt.php
@@ -24,6 +24,14 @@ class IssueCommentCreatedAt extends DateTime
         return new self($date->format('c'));
     }
 
+    public function asString(): string
+    {
+        return $this->format('c');
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->format('c');
@@ -31,7 +39,7 @@ class IssueCommentCreatedAt extends DateTime
 
     public function serialize(): string
     {
-        return $this->__toString();
+        return $this->asString();
     }
 
     public static function deserialize($value): self

--- a/src/IssueComment/IssueCommentId.php
+++ b/src/IssueComment/IssueCommentId.php
@@ -26,6 +26,19 @@ class IssueCommentId
         return $this->id;
     }
 
+    public function asInt(): int
+    {
+        return $this->id;
+    }
+
+    public function asString(): string
+    {
+        return (string) $this->id;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return (string) $this->id;

--- a/src/IssueComment/IssueCommentUpdatedAt.php
+++ b/src/IssueComment/IssueCommentUpdatedAt.php
@@ -24,6 +24,14 @@ class IssueCommentUpdatedAt extends DateTime
         return new self($date->format('c'));
     }
 
+    public function asString(): string
+    {
+        return $this->format('c');
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->format('c');
@@ -31,7 +39,7 @@ class IssueCommentUpdatedAt extends DateTime
 
     public function serialize(): string
     {
-        return $this->__toString();
+        return $this->asString();
     }
 
     public static function deserialize($value): self

--- a/src/Label/LabelColor.php
+++ b/src/Label/LabelColor.php
@@ -28,6 +28,14 @@ class LabelColor
         return $this->color;
     }
 
+    public function asString(): string
+    {
+        return $this->color;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->color;

--- a/src/Label/LabelId.php
+++ b/src/Label/LabelId.php
@@ -26,6 +26,19 @@ class LabelId
         return $this->id;
     }
 
+    public function asInt(): int
+    {
+        return $this->id;
+    }
+
+    public function asString(): string
+    {
+        return (string) $this->id;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return (string) $this->id;

--- a/src/Label/LabelName.php
+++ b/src/Label/LabelName.php
@@ -23,6 +23,14 @@ class LabelName
         return $this->value;
     }
 
+    public function asString(): string
+    {
+        return $this->value;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->value;

--- a/src/Milestone/MilestoneClosedAt.php
+++ b/src/Milestone/MilestoneClosedAt.php
@@ -24,6 +24,14 @@ class MilestoneClosedAt extends DateTime
         return new self($date->format('c'));
     }
 
+    public function asString(): string
+    {
+        return $this->format('c');
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->format('c');
@@ -31,7 +39,7 @@ class MilestoneClosedAt extends DateTime
 
     public function serialize(): string
     {
-        return $this->__toString();
+        return $this->asString();
     }
 
     public static function deserialize($value): self

--- a/src/Milestone/MilestoneCreatedAt.php
+++ b/src/Milestone/MilestoneCreatedAt.php
@@ -24,6 +24,14 @@ class MilestoneCreatedAt extends DateTime
         return new self($date->format('c'));
     }
 
+    public function asString(): string
+    {
+        return $this->format('c');
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->format('c');
@@ -31,7 +39,7 @@ class MilestoneCreatedAt extends DateTime
 
     public function serialize(): string
     {
-        return $this->__toString();
+        return $this->asString();
     }
 
     public static function deserialize($value): self

--- a/src/Milestone/MilestoneDescription.php
+++ b/src/Milestone/MilestoneDescription.php
@@ -23,6 +23,14 @@ class MilestoneDescription
         return $this->value;
     }
 
+    public function asString(): string
+    {
+        return $this->value;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->value;

--- a/src/Milestone/MilestoneDueOn.php
+++ b/src/Milestone/MilestoneDueOn.php
@@ -24,6 +24,14 @@ class MilestoneDueOn extends DateTime
         return new self($date->format('c'));
     }
 
+    public function asString(): string
+    {
+        return $this->format('c');
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->format('c');
@@ -31,7 +39,7 @@ class MilestoneDueOn extends DateTime
 
     public function serialize(): string
     {
-        return $this->__toString();
+        return $this->asString();
     }
 
     public static function deserialize($value): self

--- a/src/Milestone/MilestoneId.php
+++ b/src/Milestone/MilestoneId.php
@@ -26,6 +26,19 @@ class MilestoneId
         return $this->id;
     }
 
+    public function asInt(): int
+    {
+        return $this->id;
+    }
+
+    public function asString(): string
+    {
+        return (string) $this->id;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return (string) $this->id;

--- a/src/Milestone/MilestoneNumber.php
+++ b/src/Milestone/MilestoneNumber.php
@@ -23,6 +23,19 @@ class MilestoneNumber
         return $this->value;
     }
 
+    public function asInt(): int
+    {
+        return $this->value;
+    }
+
+    public function asString(): string
+    {
+        return (string) $this->value;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return (string) $this->value;

--- a/src/Milestone/MilestoneState.php
+++ b/src/Milestone/MilestoneState.php
@@ -16,6 +16,11 @@ class MilestoneState extends Enum
 
     const CLOSED = 'closed';
 
+    public function asString(): string
+    {
+        return $this->value;
+    }
+
     public function serialize(): string
     {
         return $this->value;

--- a/src/Milestone/MilestoneTitle.php
+++ b/src/Milestone/MilestoneTitle.php
@@ -23,6 +23,14 @@ class MilestoneTitle
         return $this->value;
     }
 
+    public function asString(): string
+    {
+        return $this->value;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->value;

--- a/src/Milestone/MilestoneUpdatedAt.php
+++ b/src/Milestone/MilestoneUpdatedAt.php
@@ -24,6 +24,14 @@ class MilestoneUpdatedAt extends DateTime
         return new self($date->format('c'));
     }
 
+    public function asString(): string
+    {
+        return $this->format('c');
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->format('c');
@@ -31,7 +39,7 @@ class MilestoneUpdatedAt extends DateTime
 
     public function serialize(): string
     {
-        return $this->__toString();
+        return $this->asString();
     }
 
     public static function deserialize($value): self

--- a/src/PullRequest/PullRequestAuthorAssociation.php
+++ b/src/PullRequest/PullRequestAuthorAssociation.php
@@ -22,6 +22,11 @@ class PullRequestAuthorAssociation extends Enum
 
     const NONE = 'NONE';
 
+    public function asString(): string
+    {
+        return $this->value;
+    }
+
     public function serialize(): string
     {
         return $this->value;

--- a/src/PullRequest/PullRequestBody.php
+++ b/src/PullRequest/PullRequestBody.php
@@ -23,6 +23,14 @@ class PullRequestBody
         return $this->value;
     }
 
+    public function asString(): string
+    {
+        return $this->value;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->value;

--- a/src/PullRequest/PullRequestClosedAt.php
+++ b/src/PullRequest/PullRequestClosedAt.php
@@ -24,6 +24,14 @@ class PullRequestClosedAt extends DateTime
         return new self($date->format('c'));
     }
 
+    public function asString(): string
+    {
+        return $this->format('c');
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->format('c');
@@ -31,7 +39,7 @@ class PullRequestClosedAt extends DateTime
 
     public function serialize(): string
     {
-        return $this->__toString();
+        return $this->asString();
     }
 
     public static function deserialize($value): self

--- a/src/PullRequest/PullRequestCreatedAt.php
+++ b/src/PullRequest/PullRequestCreatedAt.php
@@ -24,6 +24,14 @@ class PullRequestCreatedAt extends DateTime
         return new self($date->format('c'));
     }
 
+    public function asString(): string
+    {
+        return $this->format('c');
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->format('c');
@@ -31,7 +39,7 @@ class PullRequestCreatedAt extends DateTime
 
     public function serialize(): string
     {
-        return $this->__toString();
+        return $this->asString();
     }
 
     public static function deserialize($value): self

--- a/src/PullRequest/PullRequestId.php
+++ b/src/PullRequest/PullRequestId.php
@@ -26,6 +26,19 @@ class PullRequestId
         return $this->id;
     }
 
+    public function asInt(): int
+    {
+        return $this->id;
+    }
+
+    public function asString(): string
+    {
+        return (string) $this->id;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return (string) $this->id;

--- a/src/PullRequest/PullRequestNumber.php
+++ b/src/PullRequest/PullRequestNumber.php
@@ -23,6 +23,19 @@ class PullRequestNumber
         return $this->value;
     }
 
+    public function asInt(): int
+    {
+        return $this->value;
+    }
+
+    public function asString(): string
+    {
+        return (string) $this->value;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return (string) $this->value;

--- a/src/PullRequest/PullRequestState.php
+++ b/src/PullRequest/PullRequestState.php
@@ -18,6 +18,11 @@ class PullRequestState extends Enum
 
     const MERGED = 'merged';
 
+    public function asString(): string
+    {
+        return $this->value;
+    }
+
     public function serialize(): string
     {
         return $this->value;

--- a/src/PullRequest/PullRequestTitle.php
+++ b/src/PullRequest/PullRequestTitle.php
@@ -23,6 +23,14 @@ class PullRequestTitle
         return $this->value;
     }
 
+    public function asString(): string
+    {
+        return $this->value;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->value;

--- a/src/PullRequest/PullRequestUpdatedAt.php
+++ b/src/PullRequest/PullRequestUpdatedAt.php
@@ -24,6 +24,14 @@ class PullRequestUpdatedAt extends DateTime
         return new self($date->format('c'));
     }
 
+    public function asString(): string
+    {
+        return $this->format('c');
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->format('c');
@@ -31,7 +39,7 @@ class PullRequestUpdatedAt extends DateTime
 
     public function serialize(): string
     {
-        return $this->__toString();
+        return $this->asString();
     }
 
     public static function deserialize($value): self

--- a/src/PullRequestReview/PullRequestReviewAuthorAssociation.php
+++ b/src/PullRequestReview/PullRequestReviewAuthorAssociation.php
@@ -20,6 +20,11 @@ class PullRequestReviewAuthorAssociation extends Enum
 
     const NONE = 'NONE';
 
+    public function asString(): string
+    {
+        return $this->value;
+    }
+
     public function serialize(): string
     {
         return $this->value;

--- a/src/PullRequestReview/PullRequestReviewBody.php
+++ b/src/PullRequestReview/PullRequestReviewBody.php
@@ -23,6 +23,14 @@ class PullRequestReviewBody
         return $this->value;
     }
 
+    public function asString(): string
+    {
+        return $this->value;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->value;

--- a/src/PullRequestReview/PullRequestReviewHtmlUrl.php
+++ b/src/PullRequestReview/PullRequestReviewHtmlUrl.php
@@ -28,6 +28,14 @@ class PullRequestReviewHtmlUrl
         return $this->htmlUrl;
     }
 
+    public function asString(): string
+    {
+        return $this->htmlUrl;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->htmlUrl;

--- a/src/PullRequestReview/PullRequestReviewId.php
+++ b/src/PullRequestReview/PullRequestReviewId.php
@@ -26,6 +26,19 @@ class PullRequestReviewId
         return $this->id;
     }
 
+    public function asInt(): int
+    {
+        return $this->id;
+    }
+
+    public function asString(): string
+    {
+        return (string) $this->id;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return (string) $this->id;

--- a/src/PullRequestReview/PullRequestReviewState.php
+++ b/src/PullRequestReview/PullRequestReviewState.php
@@ -22,6 +22,11 @@ class PullRequestReviewState extends Enum
 
     const DISMISSED = 'dismissed';
 
+    public function asString(): string
+    {
+        return $this->value;
+    }
+
     public function serialize(): string
     {
         return $this->value;

--- a/src/PullRequestReview/PullRequestReviewSubmittedAt.php
+++ b/src/PullRequestReview/PullRequestReviewSubmittedAt.php
@@ -24,6 +24,14 @@ class PullRequestReviewSubmittedAt extends DateTime
         return new self($date->format('c'));
     }
 
+    public function asString(): string
+    {
+        return $this->format('c');
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->format('c');
@@ -31,7 +39,7 @@ class PullRequestReviewSubmittedAt extends DateTime
 
     public function serialize(): string
     {
-        return $this->__toString();
+        return $this->asString();
     }
 
     public static function deserialize($value): self

--- a/src/Repo/RepoCreatedAt.php
+++ b/src/Repo/RepoCreatedAt.php
@@ -13,6 +13,14 @@ use RuntimeException;
  */
 class RepoCreatedAt extends DateTime
 {
+    public function asString(): string
+    {
+        return $this->format('c');
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->format('c');
@@ -31,7 +39,7 @@ class RepoCreatedAt extends DateTime
 
     public function serialize(): string
     {
-        return $this->__toString();
+        return $this->asString();
     }
 
     public static function deserialize($value): self

--- a/src/Repo/RepoDescription.php
+++ b/src/Repo/RepoDescription.php
@@ -28,6 +28,14 @@ class RepoDescription
         return $this->description;
     }
 
+    public function asString(): string
+    {
+        return $this->description;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->description;

--- a/src/Repo/RepoEndpoints/RepoApiUrl.php
+++ b/src/Repo/RepoEndpoints/RepoApiUrl.php
@@ -28,6 +28,14 @@ class RepoApiUrl
         return $this->apiUrl;
     }
 
+    public function asString(): string
+    {
+        return $this->apiUrl;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->apiUrl;

--- a/src/Repo/RepoEndpoints/RepoGitUrl.php
+++ b/src/Repo/RepoEndpoints/RepoGitUrl.php
@@ -28,6 +28,14 @@ class RepoGitUrl
         return $this->gitUrl;
     }
 
+    public function asString(): string
+    {
+        return $this->gitUrl;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->gitUrl;

--- a/src/Repo/RepoEndpoints/RepoHtmlUrl.php
+++ b/src/Repo/RepoEndpoints/RepoHtmlUrl.php
@@ -28,6 +28,14 @@ class RepoHtmlUrl
         return $this->htmlUrl;
     }
 
+    public function asString(): string
+    {
+        return $this->htmlUrl;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->htmlUrl;

--- a/src/Repo/RepoEndpoints/RepoSshUrl.php
+++ b/src/Repo/RepoEndpoints/RepoSshUrl.php
@@ -28,6 +28,14 @@ class RepoSshUrl
         return $this->sshUrl;
     }
 
+    public function asString(): string
+    {
+        return $this->sshUrl;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->sshUrl;

--- a/src/Repo/RepoFullName.php
+++ b/src/Repo/RepoFullName.php
@@ -36,6 +36,14 @@ class RepoFullName
         return $this->owner->getValue().'/'.$this->repoName->getValue();
     }
 
+    public function asString(): string
+    {
+        return $this->getValue();
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->getValue();

--- a/src/Repo/RepoHomepage.php
+++ b/src/Repo/RepoHomepage.php
@@ -28,6 +28,14 @@ class RepoHomepage
         return $this->homepage;
     }
 
+    public function asString(): string
+    {
+        return $this->homepage;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->homepage;

--- a/src/Repo/RepoId.php
+++ b/src/Repo/RepoId.php
@@ -26,6 +26,19 @@ class RepoId
         return $this->id;
     }
 
+    public function asInt(): int
+    {
+        return $this->id;
+    }
+
+    public function asString(): string
+    {
+        return (string) $this->id;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return (string) $this->id;

--- a/src/Repo/RepoLanguage.php
+++ b/src/Repo/RepoLanguage.php
@@ -28,6 +28,14 @@ class RepoLanguage
         return $this->language;
     }
 
+    public function asString(): string
+    {
+        return $this->language;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->language;

--- a/src/Repo/RepoMirrorUrl.php
+++ b/src/Repo/RepoMirrorUrl.php
@@ -28,6 +28,14 @@ class RepoMirrorUrl
         return $this->mirrorUrl;
     }
 
+    public function asString(): string
+    {
+        return $this->mirrorUrl;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->mirrorUrl;

--- a/src/Repo/RepoName.php
+++ b/src/Repo/RepoName.php
@@ -28,6 +28,14 @@ class RepoName
         return $this->name;
     }
 
+    public function asString(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->name;

--- a/src/Repo/RepoPushedAt.php
+++ b/src/Repo/RepoPushedAt.php
@@ -13,6 +13,14 @@ use RuntimeException;
  */
 class RepoPushedAt extends DateTime
 {
+    public function asString(): string
+    {
+        return $this->format('c');
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->format('c');
@@ -31,7 +39,7 @@ class RepoPushedAt extends DateTime
 
     public function serialize(): string
     {
-        return $this->__toString();
+        return $this->asString();
     }
 
     public static function deserialize($value): self

--- a/src/Repo/RepoStats/RepoSize.php
+++ b/src/Repo/RepoStats/RepoSize.php
@@ -28,6 +28,19 @@ class RepoSize
         return $this->size;
     }
 
+    public function asInt(): int
+    {
+        return $this->size;
+    }
+
+    public function asString(): string
+    {
+        return (string) $this->size;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return (string) $this->size;

--- a/src/Repo/RepoUpdatedAt.php
+++ b/src/Repo/RepoUpdatedAt.php
@@ -13,6 +13,14 @@ use RuntimeException;
  */
 class RepoUpdatedAt extends DateTime
 {
+    public function asString(): string
+    {
+        return $this->format('c');
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->format('c');
@@ -31,7 +39,7 @@ class RepoUpdatedAt extends DateTime
 
     public function serialize(): string
     {
-        return $this->__toString();
+        return $this->asString();
     }
 
     public static function deserialize($value): self

--- a/src/Stats.php
+++ b/src/Stats.php
@@ -23,6 +23,19 @@ abstract class Stats
         return $this->id;
     }
 
+    public function asInt(): int
+    {
+        return $this->id;
+    }
+
+    public function asString(): string
+    {
+        return (string) $this->id;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return (string) $this->id;

--- a/src/Status/StatusState.php
+++ b/src/Status/StatusState.php
@@ -20,6 +20,14 @@ abstract class StatusState
         return $this->getName();
     }
 
+    public function asString(): string
+    {
+        return $this->getName();
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->getName();

--- a/src/StatusCheck/StatusCheckContext.php
+++ b/src/StatusCheck/StatusCheckContext.php
@@ -28,6 +28,14 @@ class StatusCheckContext
         return $this->description;
     }
 
+    public function asString(): string
+    {
+        return $this->description;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->description;

--- a/src/StatusCheck/StatusCheckDescription.php
+++ b/src/StatusCheck/StatusCheckDescription.php
@@ -23,6 +23,14 @@ class StatusCheckDescription
         return $this->value;
     }
 
+    public function asString(): string
+    {
+        return $this->value;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->value;

--- a/src/StatusCheck/StatusCheckId.php
+++ b/src/StatusCheck/StatusCheckId.php
@@ -26,6 +26,19 @@ class StatusCheckId
         return $this->id;
     }
 
+    public function asInt(): int
+    {
+        return $this->id;
+    }
+
+    public function asString(): string
+    {
+        return (string) $this->id;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return (string) $this->id;

--- a/src/StatusCheck/StatusCheckState.php
+++ b/src/StatusCheck/StatusCheckState.php
@@ -20,6 +20,14 @@ abstract class StatusCheckState
         return $this->getName();
     }
 
+    public function asString(): string
+    {
+        return $this->getName();
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->getName();

--- a/src/StatusCheck/StatusCheckTargetUrl.php
+++ b/src/StatusCheck/StatusCheckTargetUrl.php
@@ -28,6 +28,14 @@ class StatusCheckTargetUrl
         return $this->targetUrl;
     }
 
+    public function asString(): string
+    {
+        return $this->targetUrl;
+    }
+
+    /**
+     * @deprecated Please use `asString()`
+     */
     public function __toString(): string
     {
         return $this->targetUrl;

--- a/tests/Account/AccountAvatarUrlTest.php
+++ b/tests/Account/AccountAvatarUrlTest.php
@@ -37,7 +37,7 @@ class AccountAvatarUrlTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame($this->avatarUrl, $this->sut->__toString());
+        self::assertSame($this->avatarUrl, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Account/AccountIdTest.php
+++ b/tests/Account/AccountIdTest.php
@@ -32,7 +32,7 @@ class AccountIdTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame((string) $this->id, $this->sut->__toString());
+        self::assertSame((string) $this->id, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Account/AccountLoginTest.php
+++ b/tests/Account/AccountLoginTest.php
@@ -32,7 +32,7 @@ class AccountLoginTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame($this->value, $this->sut->__toString());
+        self::assertSame($this->value, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Application/ApplicationIdTest.php
+++ b/tests/Application/ApplicationIdTest.php
@@ -32,7 +32,7 @@ class ApplicationIdTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame((string) $this->id, $this->sut->__toString());
+        self::assertSame((string) $this->id, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Branch/BranchProtectionUrlTest.php
+++ b/tests/Branch/BranchProtectionUrlTest.php
@@ -37,7 +37,7 @@ class BranchProtectionUrlTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame($this->protectionUrl, $this->sut->__toString());
+        self::assertSame($this->protectionUrl, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Branch/Protection/RequiredStatusChecks/Context/ContextIdTest.php
+++ b/tests/Branch/Protection/RequiredStatusChecks/Context/ContextIdTest.php
@@ -32,7 +32,7 @@ class ContextIdTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame((string) $this->id, $this->sut->__toString());
+        self::assertSame((string) $this->id, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Branch/Protection/RequiredStatusChecks/RequiredStatusChecksEnforcementLevelTest.php
+++ b/tests/Branch/Protection/RequiredStatusChecks/RequiredStatusChecksEnforcementLevelTest.php
@@ -37,7 +37,7 @@ class RequiredStatusChecksEnforcementLevelTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame($this->enforcementLevel, $this->sut->__toString());
+        self::assertSame($this->enforcementLevel, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Build/Status/CreatedTest.php
+++ b/tests/Build/Status/CreatedTest.php
@@ -31,7 +31,7 @@ class CreatedTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertEquals('created', $this->sut->__toString());
+        self::assertEquals('created', $this->sut->asString());
     }
 
     public function testConstName(): void

--- a/tests/Build/Status/ErroredTest.php
+++ b/tests/Build/Status/ErroredTest.php
@@ -31,7 +31,7 @@ class ErroredTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertEquals('errored', $this->sut->__toString());
+        self::assertEquals('errored', $this->sut->asString());
     }
 
     public function testConstName(): void

--- a/tests/Build/Status/FailedTest.php
+++ b/tests/Build/Status/FailedTest.php
@@ -31,7 +31,7 @@ class FailedTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertEquals('failed', $this->sut->__toString());
+        self::assertEquals('failed', $this->sut->asString());
     }
 
     public function testConstName(): void

--- a/tests/Build/Status/FailingTest.php
+++ b/tests/Build/Status/FailingTest.php
@@ -31,7 +31,7 @@ class FailingTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertEquals('failing', $this->sut->__toString());
+        self::assertEquals('failing', $this->sut->asString());
     }
 
     public function testConstName(): void

--- a/tests/Build/Status/InProgressTest.php
+++ b/tests/Build/Status/InProgressTest.php
@@ -31,7 +31,7 @@ class InProgressTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertEquals('in_progress', $this->sut->__toString());
+        self::assertEquals('in_progress', $this->sut->asString());
     }
 
     public function testConstName(): void

--- a/tests/Build/Status/PassedTest.php
+++ b/tests/Build/Status/PassedTest.php
@@ -31,7 +31,7 @@ class PassedTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertEquals('passed', $this->sut->__toString());
+        self::assertEquals('passed', $this->sut->asString());
     }
 
     public function testConstName(): void

--- a/tests/Commit/CommitCommentCountTest.php
+++ b/tests/Commit/CommitCommentCountTest.php
@@ -37,7 +37,7 @@ class CommitCommentCountTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame((string) $this->commentCount, $this->sut->__toString());
+        self::assertSame((string) $this->commentCount, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Commit/CommitCommentsUrlTest.php
+++ b/tests/Commit/CommitCommentsUrlTest.php
@@ -37,7 +37,7 @@ class CommitCommentsUrlTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame($this->commentsUrl, $this->sut->__toString());
+        self::assertSame($this->commentsUrl, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Commit/Verification/VerificationPayloadTest.php
+++ b/tests/Commit/Verification/VerificationPayloadTest.php
@@ -37,7 +37,7 @@ class VerificationPayloadTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame($this->payload, $this->sut->__toString());
+        self::assertSame($this->payload, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Commit/Verification/VerificationReasonTest.php
+++ b/tests/Commit/Verification/VerificationReasonTest.php
@@ -37,7 +37,7 @@ class VerificationReasonTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame($this->reason, $this->sut->__toString());
+        self::assertSame($this->reason, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Commit/Verification/VerificationSignatureTest.php
+++ b/tests/Commit/Verification/VerificationSignatureTest.php
@@ -37,7 +37,7 @@ class VerificationSignatureTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame($this->signature, $this->sut->__toString());
+        self::assertSame($this->signature, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Commit/Verification/VerificationVerifiedTest.php
+++ b/tests/Commit/Verification/VerificationVerifiedTest.php
@@ -37,7 +37,7 @@ class VerificationVerifiedTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame('true', $this->sut->__toString());
+        self::assertSame('true', $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/External/Service/CodeCoverage/CodeCovIoTest.php
+++ b/tests/External/Service/CodeCoverage/CodeCovIoTest.php
@@ -38,7 +38,7 @@ class CodeCovIoTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertEquals('CodecovIO', $this->sut->__toString());
+        self::assertEquals('CodecovIO', $this->sut->asString());
     }
 
     public function testGetContext(): void

--- a/tests/External/Service/CodeCoverage/CoverallsIoTest.php
+++ b/tests/External/Service/CodeCoverage/CoverallsIoTest.php
@@ -38,7 +38,7 @@ class CoverallsIoTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertEquals('CoverallsIO', $this->sut->__toString());
+        self::assertEquals('CoverallsIO', $this->sut->asString());
     }
 
     public function testGetContext(): void

--- a/tests/External/Service/ContinuousIntegration/AppVeyorTest.php
+++ b/tests/External/Service/ContinuousIntegration/AppVeyorTest.php
@@ -38,7 +38,7 @@ class AppVeyorTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertEquals('AppVeyor', $this->sut->__toString());
+        self::assertEquals('AppVeyor', $this->sut->asString());
     }
 
     public function testGetContext(): void

--- a/tests/External/Service/ContinuousIntegration/CircleCiTest.php
+++ b/tests/External/Service/ContinuousIntegration/CircleCiTest.php
@@ -38,7 +38,7 @@ class CircleCiTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertEquals('CircleCI', $this->sut->__toString());
+        self::assertEquals('CircleCI', $this->sut->asString());
     }
 
     public function testGetContext(): void

--- a/tests/External/Service/ContinuousIntegration/FabbotIoTest.php
+++ b/tests/External/Service/ContinuousIntegration/FabbotIoTest.php
@@ -38,7 +38,7 @@ class FabbotIoTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertEquals('fabbot.io', $this->sut->__toString());
+        self::assertEquals('fabbot.io', $this->sut->asString());
     }
 
     public function testGetContext(): void

--- a/tests/External/Service/ContinuousIntegration/JenkinsTest.php
+++ b/tests/External/Service/ContinuousIntegration/JenkinsTest.php
@@ -38,7 +38,7 @@ class JenkinsTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertEquals('Jenkins', $this->sut->__toString());
+        self::assertEquals('Jenkins', $this->sut->asString());
     }
 
     public function testGetContext(): void

--- a/tests/External/Service/ContinuousIntegration/ShippableTest.php
+++ b/tests/External/Service/ContinuousIntegration/ShippableTest.php
@@ -38,7 +38,7 @@ class ShippableTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertEquals('Shippable', $this->sut->__toString());
+        self::assertEquals('Shippable', $this->sut->asString());
     }
 
     public function testGetContext(): void

--- a/tests/External/Service/ContinuousIntegration/TravisCiTest.php
+++ b/tests/External/Service/ContinuousIntegration/TravisCiTest.php
@@ -38,7 +38,7 @@ class TravisCiTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertEquals('TravisCI', $this->sut->__toString());
+        self::assertEquals('TravisCI', $this->sut->asString());
     }
 
     public function testGetContext(): void

--- a/tests/External/Service/UnknownServiceTest.php
+++ b/tests/External/Service/UnknownServiceTest.php
@@ -33,7 +33,7 @@ class UnknownServiceTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertEquals('unknown', $this->sut->__toString());
+        self::assertEquals('unknown', $this->sut->asString());
     }
 
     public function testGetContext(): void

--- a/tests/Installation/InstallationAccessTokenUrlTest.php
+++ b/tests/Installation/InstallationAccessTokenUrlTest.php
@@ -37,7 +37,7 @@ class InstallationAccessTokenUrlTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame($this->accessTokenUrl, $this->sut->__toString());
+        self::assertSame($this->accessTokenUrl, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Installation/InstallationCreatedAtTest.php
+++ b/tests/Installation/InstallationCreatedAtTest.php
@@ -25,12 +25,12 @@ class InstallationCreatedAtTest extends TestCase
     public function testCreateFromFormat(): void
     {
         $result = $this->sut::createFromFormat(DateTime::ATOM, '2018-01-01T11:22:33Z');
-        self::assertEquals('2018-01-01T11:22:33+00:00', $result->__toString());
+        self::assertEquals('2018-01-01T11:22:33+00:00', $result->asString());
     }
 
     public function testToString(): void
     {
-        self::assertSame('2018-01-01T11:22:33+00:00', $this->sut->__toString());
+        self::assertSame('2018-01-01T11:22:33+00:00', $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Installation/InstallationHtmlUrlTest.php
+++ b/tests/Installation/InstallationHtmlUrlTest.php
@@ -37,7 +37,7 @@ class InstallationHtmlUrlTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame($this->installationHtmlUrl, $this->sut->__toString());
+        self::assertSame($this->installationHtmlUrl, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Installation/InstallationIdTest.php
+++ b/tests/Installation/InstallationIdTest.php
@@ -32,7 +32,7 @@ class InstallationIdTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame((string) $this->id, $this->sut->__toString());
+        self::assertSame((string) $this->id, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Installation/InstallationRepositoriesUrlTest.php
+++ b/tests/Installation/InstallationRepositoriesUrlTest.php
@@ -37,7 +37,7 @@ class InstallationRepositoriesUrlTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame($this->installationRepositoriesUrl, $this->sut->__toString());
+        self::assertSame($this->installationRepositoriesUrl, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Installation/InstallationUpdatedAtTest.php
+++ b/tests/Installation/InstallationUpdatedAtTest.php
@@ -25,12 +25,12 @@ class InstallationUpdatedAtTest extends TestCase
     public function testCreateFromFormat(): void
     {
         $result = $this->sut::createFromFormat(DateTime::ATOM, '2018-01-01T11:22:33Z');
-        self::assertEquals('2018-01-01T11:22:33+00:00', $result->__toString());
+        self::assertEquals('2018-01-01T11:22:33+00:00', $result->asString());
     }
 
     public function testToString(): void
     {
-        self::assertSame('2018-01-01T11:22:33+00:00', $this->sut->__toString());
+        self::assertSame('2018-01-01T11:22:33+00:00', $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Issue/IssueBodyTest.php
+++ b/tests/Issue/IssueBodyTest.php
@@ -32,7 +32,7 @@ class IssueBodyTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame($this->value, $this->sut->__toString());
+        self::assertSame($this->value, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Issue/IssueClosedAtTest.php
+++ b/tests/Issue/IssueClosedAtTest.php
@@ -25,12 +25,12 @@ class IssueClosedAtTest extends TestCase
     public function testCreateFromFormat(): void
     {
         $result = $this->sut::createFromFormat(DateTime::ATOM, '2018-01-01T11:22:33Z');
-        self::assertEquals('2018-01-01T11:22:33+00:00', $result->__toString());
+        self::assertEquals('2018-01-01T11:22:33+00:00', $result->asString());
     }
 
     public function testToString(): void
     {
-        self::assertSame('2018-01-01T11:22:33+00:00', $this->sut->__toString());
+        self::assertSame('2018-01-01T11:22:33+00:00', $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Issue/IssueCreatedAtTest.php
+++ b/tests/Issue/IssueCreatedAtTest.php
@@ -25,12 +25,12 @@ class IssueCreatedAtTest extends TestCase
     public function testCreateFromFormat(): void
     {
         $result = $this->sut::createFromFormat(DateTime::ATOM, '2018-01-01T11:22:33Z');
-        self::assertEquals('2018-01-01T11:22:33+00:00', $result->__toString());
+        self::assertEquals('2018-01-01T11:22:33+00:00', $result->asString());
     }
 
     public function testToString(): void
     {
-        self::assertSame('2018-01-01T11:22:33+00:00', $this->sut->__toString());
+        self::assertSame('2018-01-01T11:22:33+00:00', $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Issue/IssueIdTest.php
+++ b/tests/Issue/IssueIdTest.php
@@ -32,7 +32,7 @@ class IssueIdTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame((string) $this->id, $this->sut->__toString());
+        self::assertSame((string) $this->id, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Issue/IssueNumberTest.php
+++ b/tests/Issue/IssueNumberTest.php
@@ -32,7 +32,7 @@ class IssueNumberTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame((string) $this->value, $this->sut->__toString());
+        self::assertSame((string) $this->value, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Issue/IssueStateTest.php
+++ b/tests/Issue/IssueStateTest.php
@@ -32,7 +32,7 @@ class IssueStateTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame($this->value, $this->sut->__toString());
+        self::assertSame($this->value, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Issue/IssueTitleTest.php
+++ b/tests/Issue/IssueTitleTest.php
@@ -32,7 +32,7 @@ class IssueTitleTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame($this->value, $this->sut->__toString());
+        self::assertSame($this->value, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Issue/IssueUpdatedAtTest.php
+++ b/tests/Issue/IssueUpdatedAtTest.php
@@ -25,12 +25,12 @@ class IssueUpdatedAtTest extends TestCase
     public function testCreateFromFormat(): void
     {
         $result = $this->sut::createFromFormat(DateTime::ATOM, '2018-01-01T11:22:33Z');
-        self::assertEquals('2018-01-01T11:22:33+00:00', $result->__toString());
+        self::assertEquals('2018-01-01T11:22:33+00:00', $result->asString());
     }
 
     public function testToString(): void
     {
-        self::assertSame('2018-01-01T11:22:33+00:00', $this->sut->__toString());
+        self::assertSame('2018-01-01T11:22:33+00:00', $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/IssueComment/IssueCommentBodyTest.php
+++ b/tests/IssueComment/IssueCommentBodyTest.php
@@ -32,7 +32,7 @@ class IssueCommentBodyTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame($this->value, $this->sut->__toString());
+        self::assertSame($this->value, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/IssueComment/IssueCommentCreatedAtTest.php
+++ b/tests/IssueComment/IssueCommentCreatedAtTest.php
@@ -25,12 +25,12 @@ class IssueCommentCreatedAtTest extends TestCase
     public function testCreateFromFormat(): void
     {
         $result = $this->sut::createFromFormat(DateTime::ATOM, '2018-01-01T11:22:33Z');
-        self::assertEquals('2018-01-01T11:22:33+00:00', $result->__toString());
+        self::assertEquals('2018-01-01T11:22:33+00:00', $result->asString());
     }
 
     public function testToString(): void
     {
-        self::assertSame('2018-01-01T11:22:33+00:00', $this->sut->__toString());
+        self::assertSame('2018-01-01T11:22:33+00:00', $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/IssueComment/IssueCommentIdTest.php
+++ b/tests/IssueComment/IssueCommentIdTest.php
@@ -32,7 +32,7 @@ class IssueCommentIdTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame((string) $this->id, $this->sut->__toString());
+        self::assertSame((string) $this->id, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/IssueComment/IssueCommentUpdatedAtTest.php
+++ b/tests/IssueComment/IssueCommentUpdatedAtTest.php
@@ -25,12 +25,12 @@ class IssueCommentUpdatedAtTest extends TestCase
     public function testCreateFromFormat(): void
     {
         $result = $this->sut::createFromFormat(DateTime::ATOM, '2018-01-01T11:22:33Z');
-        self::assertEquals('2018-01-01T11:22:33+00:00', $result->__toString());
+        self::assertEquals('2018-01-01T11:22:33+00:00', $result->asString());
     }
 
     public function testToString(): void
     {
-        self::assertSame('2018-01-01T11:22:33+00:00', $this->sut->__toString());
+        self::assertSame('2018-01-01T11:22:33+00:00', $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Label/LabelColorTest.php
+++ b/tests/Label/LabelColorTest.php
@@ -37,7 +37,7 @@ class LabelColorTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame($this->color, $this->sut->__toString());
+        self::assertSame($this->color, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Label/LabelIdTest.php
+++ b/tests/Label/LabelIdTest.php
@@ -32,7 +32,7 @@ class LabelIdTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame((string) $this->id, $this->sut->__toString());
+        self::assertSame((string) $this->id, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Label/LabelNameTest.php
+++ b/tests/Label/LabelNameTest.php
@@ -32,7 +32,7 @@ class LabelNameTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame($this->value, $this->sut->__toString());
+        self::assertSame($this->value, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Milestone/MilestoneClosedAtTest.php
+++ b/tests/Milestone/MilestoneClosedAtTest.php
@@ -25,12 +25,12 @@ class MilestoneClosedAtTest extends TestCase
     public function testCreateFromFormat(): void
     {
         $result = $this->sut::createFromFormat(DateTime::ATOM, '2018-01-01T11:22:33Z');
-        self::assertEquals('2018-01-01T11:22:33+00:00', $result->__toString());
+        self::assertEquals('2018-01-01T11:22:33+00:00', $result->asString());
     }
 
     public function testToString(): void
     {
-        self::assertSame('2018-01-01T11:22:33+00:00', $this->sut->__toString());
+        self::assertSame('2018-01-01T11:22:33+00:00', $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Milestone/MilestoneCreatedAtTest.php
+++ b/tests/Milestone/MilestoneCreatedAtTest.php
@@ -25,12 +25,12 @@ class MilestoneCreatedAtTest extends TestCase
     public function testCreateFromFormat(): void
     {
         $result = $this->sut::createFromFormat(DateTime::ATOM, '2018-01-01T11:22:33Z');
-        self::assertEquals('2018-01-01T11:22:33+00:00', $result->__toString());
+        self::assertEquals('2018-01-01T11:22:33+00:00', $result->asString());
     }
 
     public function testToString(): void
     {
-        self::assertSame('2018-01-01T11:22:33+00:00', $this->sut->__toString());
+        self::assertSame('2018-01-01T11:22:33+00:00', $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Milestone/MilestoneDescriptionTest.php
+++ b/tests/Milestone/MilestoneDescriptionTest.php
@@ -32,7 +32,7 @@ class MilestoneDescriptionTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame($this->value, $this->sut->__toString());
+        self::assertSame($this->value, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Milestone/MilestoneDueOnTest.php
+++ b/tests/Milestone/MilestoneDueOnTest.php
@@ -25,12 +25,12 @@ class MilestoneDueOnTest extends TestCase
     public function testCreateFromFormat(): void
     {
         $result = $this->sut::createFromFormat(DateTime::ATOM, '2018-01-01T11:22:33Z');
-        self::assertEquals('2018-01-01T11:22:33+00:00', $result->__toString());
+        self::assertEquals('2018-01-01T11:22:33+00:00', $result->asString());
     }
 
     public function testToString(): void
     {
-        self::assertSame('2018-01-01T11:22:33+00:00', $this->sut->__toString());
+        self::assertSame('2018-01-01T11:22:33+00:00', $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Milestone/MilestoneIdTest.php
+++ b/tests/Milestone/MilestoneIdTest.php
@@ -32,7 +32,7 @@ class MilestoneIdTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame((string) $this->id, $this->sut->__toString());
+        self::assertSame((string) $this->id, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Milestone/MilestoneNumberTest.php
+++ b/tests/Milestone/MilestoneNumberTest.php
@@ -32,7 +32,7 @@ class MilestoneNumberTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame((string) $this->value, $this->sut->__toString());
+        self::assertSame((string) $this->value, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Milestone/MilestoneStateTest.php
+++ b/tests/Milestone/MilestoneStateTest.php
@@ -32,7 +32,7 @@ class MilestoneStateTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame($this->value, $this->sut->__toString());
+        self::assertSame($this->value, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Milestone/MilestoneTitleTest.php
+++ b/tests/Milestone/MilestoneTitleTest.php
@@ -32,7 +32,7 @@ class MilestoneTitleTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame($this->value, $this->sut->__toString());
+        self::assertSame($this->value, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Milestone/MilestoneUpdatedAtTest.php
+++ b/tests/Milestone/MilestoneUpdatedAtTest.php
@@ -25,12 +25,12 @@ class MilestoneUpdatedAtTest extends TestCase
     public function testCreateFromFormat(): void
     {
         $result = $this->sut::createFromFormat(DateTime::ATOM, '2018-01-01T11:22:33Z');
-        self::assertEquals('2018-01-01T11:22:33+00:00', $result->__toString());
+        self::assertEquals('2018-01-01T11:22:33+00:00', $result->asString());
     }
 
     public function testToString(): void
     {
-        self::assertSame('2018-01-01T11:22:33+00:00', $this->sut->__toString());
+        self::assertSame('2018-01-01T11:22:33+00:00', $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/PullRequest/PullRequestAuthorAssociationTest.php
+++ b/tests/PullRequest/PullRequestAuthorAssociationTest.php
@@ -32,7 +32,7 @@ class PullRequestAuthorAssociationTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame($this->value, $this->sut->__toString());
+        self::assertSame($this->value, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/PullRequest/PullRequestBodyTest.php
+++ b/tests/PullRequest/PullRequestBodyTest.php
@@ -32,7 +32,7 @@ class PullRequestBodyTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame($this->value, $this->sut->__toString());
+        self::assertSame($this->value, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/PullRequest/PullRequestClosedAtTest.php
+++ b/tests/PullRequest/PullRequestClosedAtTest.php
@@ -25,12 +25,12 @@ class PullRequestClosedAtTest extends TestCase
     public function testCreateFromFormat(): void
     {
         $result = $this->sut::createFromFormat(DateTime::ATOM, '2018-01-01T11:22:33Z');
-        self::assertEquals('2018-01-01T11:22:33+00:00', $result->__toString());
+        self::assertEquals('2018-01-01T11:22:33+00:00', $result->asString());
     }
 
     public function testToString(): void
     {
-        self::assertSame('2018-01-01T11:22:33+00:00', $this->sut->__toString());
+        self::assertSame('2018-01-01T11:22:33+00:00', $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/PullRequest/PullRequestCreatedAtTest.php
+++ b/tests/PullRequest/PullRequestCreatedAtTest.php
@@ -25,12 +25,12 @@ class PullRequestCreatedAtTest extends TestCase
     public function testCreateFromFormat(): void
     {
         $result = $this->sut::createFromFormat(DateTime::ATOM, '2018-01-01T11:22:33Z');
-        self::assertEquals('2018-01-01T11:22:33+00:00', $result->__toString());
+        self::assertEquals('2018-01-01T11:22:33+00:00', $result->asString());
     }
 
     public function testToString(): void
     {
-        self::assertSame('2018-01-01T11:22:33+00:00', $this->sut->__toString());
+        self::assertSame('2018-01-01T11:22:33+00:00', $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/PullRequest/PullRequestIdTest.php
+++ b/tests/PullRequest/PullRequestIdTest.php
@@ -32,7 +32,7 @@ class PullRequestIdTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame((string) $this->id, $this->sut->__toString());
+        self::assertSame((string) $this->id, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/PullRequest/PullRequestNumberTest.php
+++ b/tests/PullRequest/PullRequestNumberTest.php
@@ -32,7 +32,7 @@ class PullRequestNumberTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame((string) $this->value, $this->sut->__toString());
+        self::assertSame((string) $this->value, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/PullRequest/PullRequestStateTest.php
+++ b/tests/PullRequest/PullRequestStateTest.php
@@ -28,7 +28,7 @@ class PullRequestStateTest extends TestCase
     public function testToString(string $stateName): void
     {
         $sut = new PullRequestState($stateName);
-        self::assertEquals($stateName, $sut->__toString());
+        self::assertEquals($stateName, $sut->asString());
     }
 
     public function provideStates(): array

--- a/tests/PullRequest/PullRequestTitleTest.php
+++ b/tests/PullRequest/PullRequestTitleTest.php
@@ -32,7 +32,7 @@ class PullRequestTitleTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame($this->value, $this->sut->__toString());
+        self::assertSame($this->value, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/PullRequest/PullRequestUpdatedAtTest.php
+++ b/tests/PullRequest/PullRequestUpdatedAtTest.php
@@ -25,12 +25,12 @@ class PullRequestUpdatedAtTest extends TestCase
     public function testCreateFromFormat(): void
     {
         $result = $this->sut::createFromFormat(DateTime::ATOM, '2018-01-01T11:22:33Z');
-        self::assertEquals('2018-01-01T11:22:33+00:00', $result->__toString());
+        self::assertEquals('2018-01-01T11:22:33+00:00', $result->asString());
     }
 
     public function testToString(): void
     {
-        self::assertSame('2018-01-01T11:22:33+00:00', $this->sut->__toString());
+        self::assertSame('2018-01-01T11:22:33+00:00', $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/PullRequestReview/PullRequestReviewAuthorAssociationTest.php
+++ b/tests/PullRequestReview/PullRequestReviewAuthorAssociationTest.php
@@ -32,7 +32,7 @@ class PullRequestReviewAuthorAssociationTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame($this->value, $this->sut->__toString());
+        self::assertSame($this->value, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/PullRequestReview/PullRequestReviewBodyTest.php
+++ b/tests/PullRequestReview/PullRequestReviewBodyTest.php
@@ -32,7 +32,7 @@ class PullRequestReviewBodyTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame($this->value, $this->sut->__toString());
+        self::assertSame($this->value, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/PullRequestReview/PullRequestReviewHtmlUrlTest.php
+++ b/tests/PullRequestReview/PullRequestReviewHtmlUrlTest.php
@@ -37,7 +37,7 @@ class PullRequestReviewHtmlUrlTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame($this->htmlUrl, $this->sut->__toString());
+        self::assertSame($this->htmlUrl, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/PullRequestReview/PullRequestReviewIdTest.php
+++ b/tests/PullRequestReview/PullRequestReviewIdTest.php
@@ -32,7 +32,7 @@ class PullRequestReviewIdTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame((string) $this->id, $this->sut->__toString());
+        self::assertSame((string) $this->id, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/PullRequestReview/PullRequestReviewStateTest.php
+++ b/tests/PullRequestReview/PullRequestReviewStateTest.php
@@ -32,7 +32,7 @@ class PullRequestReviewStateTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame($this->value, $this->sut->__toString());
+        self::assertSame($this->value, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/PullRequestReview/PullRequestReviewSubmittedAtTest.php
+++ b/tests/PullRequestReview/PullRequestReviewSubmittedAtTest.php
@@ -25,12 +25,12 @@ class PullRequestReviewSubmittedAtTest extends TestCase
     public function testCreateFromFormat(): void
     {
         $result = $this->sut::createFromFormat(DateTime::ATOM, '2018-01-01T11:22:33Z');
-        self::assertEquals('2018-01-01T11:22:33+00:00', $result->__toString());
+        self::assertEquals('2018-01-01T11:22:33+00:00', $result->asString());
     }
 
     public function testToString(): void
     {
-        self::assertSame('2018-01-01T11:22:33+00:00', $this->sut->__toString());
+        self::assertSame('2018-01-01T11:22:33+00:00', $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Repo/RepoCreatedAtTest.php
+++ b/tests/Repo/RepoCreatedAtTest.php
@@ -25,12 +25,12 @@ class RepoCreatedAtTest extends TestCase
     public function testCreateFromFormat(): void
     {
         $result = $this->sut::createFromFormat(DateTime::ATOM, '2018-01-01T11:22:33Z');
-        self::assertEquals('2018-01-01T11:22:33+00:00', $result->__toString());
+        self::assertEquals('2018-01-01T11:22:33+00:00', $result->asString());
     }
 
     public function testToString(): void
     {
-        self::assertSame('2018-01-01T11:22:33+00:00', $this->sut->__toString());
+        self::assertSame('2018-01-01T11:22:33+00:00', $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Repo/RepoDescriptionTest.php
+++ b/tests/Repo/RepoDescriptionTest.php
@@ -37,7 +37,7 @@ class RepoDescriptionTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame($this->description, $this->sut->__toString());
+        self::assertSame($this->description, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Repo/RepoEndpoints/RepoApiUrlTest.php
+++ b/tests/Repo/RepoEndpoints/RepoApiUrlTest.php
@@ -37,7 +37,7 @@ class RepoApiUrlTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame($this->apiUrl, $this->sut->__toString());
+        self::assertSame($this->apiUrl, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Repo/RepoEndpoints/RepoGitUrlTest.php
+++ b/tests/Repo/RepoEndpoints/RepoGitUrlTest.php
@@ -37,7 +37,7 @@ class RepoGitUrlTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame($this->gitUrl, $this->sut->__toString());
+        self::assertSame($this->gitUrl, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Repo/RepoEndpoints/RepoHtmlUrlTest.php
+++ b/tests/Repo/RepoEndpoints/RepoHtmlUrlTest.php
@@ -37,7 +37,7 @@ class RepoHtmlUrlTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame($this->htmlUrl, $this->sut->__toString());
+        self::assertSame($this->htmlUrl, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Repo/RepoEndpoints/RepoSshUrlTest.php
+++ b/tests/Repo/RepoEndpoints/RepoSshUrlTest.php
@@ -37,7 +37,7 @@ class RepoSshUrlTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame($this->sshUrl, $this->sut->__toString());
+        self::assertSame($this->sshUrl, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Repo/RepoHomepageTest.php
+++ b/tests/Repo/RepoHomepageTest.php
@@ -37,7 +37,7 @@ class RepoHomepageTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame($this->homepage, $this->sut->__toString());
+        self::assertSame($this->homepage, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Repo/RepoIdTest.php
+++ b/tests/Repo/RepoIdTest.php
@@ -32,7 +32,7 @@ class RepoIdTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame((string) $this->id, $this->sut->__toString());
+        self::assertSame((string) $this->id, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Repo/RepoLanguageTest.php
+++ b/tests/Repo/RepoLanguageTest.php
@@ -37,7 +37,7 @@ class RepoLanguageTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame($this->language, $this->sut->__toString());
+        self::assertSame($this->language, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Repo/RepoMirrorUrlTest.php
+++ b/tests/Repo/RepoMirrorUrlTest.php
@@ -37,7 +37,7 @@ class RepoMirrorUrlTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame($this->mirrorUrl, $this->sut->__toString());
+        self::assertSame($this->mirrorUrl, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Repo/RepoNameTest.php
+++ b/tests/Repo/RepoNameTest.php
@@ -37,7 +37,7 @@ class RepoNameTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame($this->name, $this->sut->__toString());
+        self::assertSame($this->name, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Repo/RepoPushedAtTest.php
+++ b/tests/Repo/RepoPushedAtTest.php
@@ -25,12 +25,12 @@ class RepoPushedAtTest extends TestCase
     public function testCreateFromFormat(): void
     {
         $result = $this->sut::createFromFormat(DateTime::ATOM, '2018-01-01T11:22:33Z');
-        self::assertEquals('2018-01-01T11:22:33+00:00', $result->__toString());
+        self::assertEquals('2018-01-01T11:22:33+00:00', $result->asString());
     }
 
     public function testToString(): void
     {
-        self::assertSame('2018-01-01T11:22:33+00:00', $this->sut->__toString());
+        self::assertSame('2018-01-01T11:22:33+00:00', $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Repo/RepoStats/RepoSizeTest.php
+++ b/tests/Repo/RepoStats/RepoSizeTest.php
@@ -37,7 +37,7 @@ class RepoSizeTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame((string) $this->size, $this->sut->__toString());
+        self::assertSame((string) $this->size, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Repo/RepoUpdatedAtTest.php
+++ b/tests/Repo/RepoUpdatedAtTest.php
@@ -25,12 +25,12 @@ class RepoUpdatedAtTest extends TestCase
     public function testCreateFromFormat(): void
     {
         $result = $this->sut::createFromFormat(DateTime::ATOM, '2018-01-01T11:22:33Z');
-        self::assertEquals('2018-01-01T11:22:33+00:00', $result->__toString());
+        self::assertEquals('2018-01-01T11:22:33+00:00', $result->asString());
     }
 
     public function testToString(): void
     {
-        self::assertSame('2018-01-01T11:22:33+00:00', $this->sut->__toString());
+        self::assertSame('2018-01-01T11:22:33+00:00', $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/Status/State/ErrorTest.php
+++ b/tests/Status/State/ErrorTest.php
@@ -31,7 +31,7 @@ class ErrorTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertEquals('error', $this->sut->__toString());
+        self::assertEquals('error', $this->sut->asString());
     }
 
     public function testConstName(): void

--- a/tests/Status/State/FailureTest.php
+++ b/tests/Status/State/FailureTest.php
@@ -31,7 +31,7 @@ class FailureTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertEquals('failure', $this->sut->__toString());
+        self::assertEquals('failure', $this->sut->asString());
     }
 
     public function testConstName(): void

--- a/tests/Status/State/PendingTest.php
+++ b/tests/Status/State/PendingTest.php
@@ -31,7 +31,7 @@ class PendingTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertEquals('pending', $this->sut->__toString());
+        self::assertEquals('pending', $this->sut->asString());
     }
 
     public function testConstName(): void

--- a/tests/Status/State/SuccessTest.php
+++ b/tests/Status/State/SuccessTest.php
@@ -31,7 +31,7 @@ class SuccessTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertEquals('success', $this->sut->__toString());
+        self::assertEquals('success', $this->sut->asString());
     }
 
     public function testConstName(): void

--- a/tests/StatusCheck/State/ErrorTest.php
+++ b/tests/StatusCheck/State/ErrorTest.php
@@ -31,7 +31,7 @@ class ErrorTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertEquals('error', $this->sut->__toString());
+        self::assertEquals('error', $this->sut->asString());
     }
 
     public function testConstName(): void

--- a/tests/StatusCheck/State/FailureTest.php
+++ b/tests/StatusCheck/State/FailureTest.php
@@ -31,7 +31,7 @@ class FailureTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertEquals('failure', $this->sut->__toString());
+        self::assertEquals('failure', $this->sut->asString());
     }
 
     public function testConstName(): void

--- a/tests/StatusCheck/State/PendingTest.php
+++ b/tests/StatusCheck/State/PendingTest.php
@@ -31,7 +31,7 @@ class PendingTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertEquals('pending', $this->sut->__toString());
+        self::assertEquals('pending', $this->sut->asString());
     }
 
     public function testConstName(): void

--- a/tests/StatusCheck/State/SuccessTest.php
+++ b/tests/StatusCheck/State/SuccessTest.php
@@ -31,7 +31,7 @@ class SuccessTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertEquals('success', $this->sut->__toString());
+        self::assertEquals('success', $this->sut->asString());
     }
 
     public function testConstName(): void

--- a/tests/StatusCheck/StatusCheckContextTest.php
+++ b/tests/StatusCheck/StatusCheckContextTest.php
@@ -37,7 +37,7 @@ class StatusCheckContextTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame($this->description, $this->sut->__toString());
+        self::assertSame($this->description, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/StatusCheck/StatusCheckDescriptionTest.php
+++ b/tests/StatusCheck/StatusCheckDescriptionTest.php
@@ -32,7 +32,7 @@ class StatusCheckDescriptionTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame($this->value, $this->sut->__toString());
+        self::assertSame($this->value, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/StatusCheck/StatusCheckIdTest.php
+++ b/tests/StatusCheck/StatusCheckIdTest.php
@@ -32,7 +32,7 @@ class StatusCheckIdTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame((string) $this->id, $this->sut->__toString());
+        self::assertSame((string) $this->id, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/StatusCheck/StatusCheckTargetUrlTest.php
+++ b/tests/StatusCheck/StatusCheckTargetUrlTest.php
@@ -37,7 +37,7 @@ class StatusCheckTargetUrlTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame($this->targetUrl, $this->sut->__toString());
+        self::assertSame($this->targetUrl, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/User/UserAvatarUrlTest.php
+++ b/tests/User/UserAvatarUrlTest.php
@@ -37,7 +37,7 @@ class UserAvatarUrlTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame($this->avatarUrl, $this->sut->__toString());
+        self::assertSame($this->avatarUrl, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/User/UserIdTest.php
+++ b/tests/User/UserIdTest.php
@@ -32,7 +32,7 @@ class UserIdTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame((string) $this->id, $this->sut->__toString());
+        self::assertSame((string) $this->id, $this->sut->asString());
     }
 
     public function testSerialize(): void

--- a/tests/User/UserLoginTest.php
+++ b/tests/User/UserLoginTest.php
@@ -32,7 +32,7 @@ class UserLoginTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertSame($this->value, $this->sut->__toString());
+        self::assertSame($this->value, $this->sut->asString());
     }
 
     public function testSerialize(): void


### PR DESCRIPTION
Lets try to avoid magic methods...